### PR TITLE
With the release of .NET Core 3.0, many ASP.NET Core assemblies are n…

### DIFF
--- a/src/Arc4u.Standard.AspNetCore.gRpc/Arc4u.Standard.AspNetCore.gRpc.csproj
+++ b/src/Arc4u.Standard.AspNetCore.gRpc/Arc4u.Standard.AspNetCore.gRpc.csproj
@@ -20,9 +20,8 @@
 
   <ItemGroup>
     <PackageReference Include="Grpc.AspNetCore.Server" Version="2.40.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
   </ItemGroup>
-
+  
   <ItemGroup>
     <ProjectReference Include="..\Arc4u.Standard.Dependency\Arc4u.Standard.Dependency.csproj" />
     <ProjectReference Include="..\Arc4u.Standard.Diagnostics\Arc4u.Standard.Diagnostics.csproj" />

--- a/src/Arc4u.Standard.OAuth.AspNetCore.Msal/Arc4u.Standard.OAuth2.AspNetCore.Msal.csproj
+++ b/src/Arc4u.Standard.OAuth.AspNetCore.Msal/Arc4u.Standard.OAuth2.AspNetCore.Msal.csproj
@@ -27,20 +27,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authorization.Policy" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
     <PackageReference Include="Microsoft.Identity.Web" Version="1.*" />
     <ProjectReference Include="..\Arc4u.Standard.OAuth2.AspNetCore\Arc4u.Standard.OAuth2.AspNetCore.csproj" />
   </ItemGroup>
-
 
   <ItemGroup>
     <None Include="..\..\LICENSE">
       <Pack>True</Pack>
       <PackagePath></PackagePath>
-    </None>
-  </ItemGroup>
+    </None>  </ItemGroup>
 
 
   <ItemGroup>

--- a/src/Arc4u.Standard.OAuth2.AspNetCore.Api/Arc4u.Standard.OAuth2.AspNetCore.Api.csproj
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore.Api/Arc4u.Standard.OAuth2.AspNetCore.Api.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1</TargetFrameworks>
     <Version>9.9.9.9</Version>
     <Authors>Gilles Flisch</Authors>
     <Description>Package used on Interface and Façade projects</Description>
@@ -17,10 +17,14 @@
     <RootNamespace>Arc4u.OAuth2</RootNamespace>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+  
   <ItemGroup>
     <ProjectReference Include="..\Arc4u.Standard.Diagnostics\Arc4u.Standard.Diagnostics.csproj" />
     <ProjectReference Include="..\Arc4u.Standard\Arc4u.Standard.csproj" />

--- a/src/Arc4u.Standard.OAuth2.AspNetCore.Blazor/Arc4u.Standard.OAuth2.AspNetCore.Blazor.csproj
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore.Blazor/Arc4u.Standard.OAuth2.AspNetCore.Blazor.csproj
@@ -16,12 +16,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <RootNamespace>Arc4u.Blazor</RootNamespace>
   </PropertyGroup>
-  
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
-  </ItemGroup>
-
+ 
   <ItemGroup>
     <None Include="..\..\LICENSE">
       <Pack>True</Pack>

--- a/src/Arc4u.Standard.OAuth2.AspNetCore/Arc4u.Standard.OAuth2.AspNetCore.csproj
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore/Arc4u.Standard.OAuth2.AspNetCore.csproj
@@ -19,11 +19,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.11" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="5.0.11" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Arc4u.Standard.OAuth2.Blazor/Arc4u.Standard.OAuth2.Blazor.csproj
+++ b/src/Arc4u.Standard.OAuth2.Blazor/Arc4u.Standard.OAuth2.Blazor.csproj
@@ -18,16 +18,14 @@
     <PackageTags>Arc4u</PackageTags>
   </PropertyGroup>
 
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Blazored.LocalStorage" Version="4.1.5" />
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="5.0.11" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="5.0.11" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="5.0.11" />
   </ItemGroup>
-
 
   <ItemGroup>
     <None Include="..\..\LICENSE">
@@ -35,7 +33,6 @@
       <PackagePath></PackagePath>
     </None>
   </ItemGroup>
-
 
   <ItemGroup>
     <ProjectReference Include="..\Arc4u.Standard.OAuth2.Client\Arc4u.Standard.OAuth2.Client.csproj" />

--- a/src/Arc4u.Standard.gRPC/Arc4u.Standard.gRPC.csproj
+++ b/src/Arc4u.Standard.gRPC/Arc4u.Standard.gRPC.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>Arc4u.gRPC</RootNamespace>
     <Authors>Gilles Flisch</Authors>
     <Description>Core Framework to use gRPC.</Description>
@@ -14,11 +14,18 @@
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <Version>9.9.9.9</Version>
   </PropertyGroup>
-    
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Grpc.Core.Api" Version="2.41.0" />
     <PackageReference Include="GrpcRichError" Version="0.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Arc4u.standard.OAuth2.Adal/Arc4u.Standard.OAuth2.Adal.csproj
+++ b/src/Arc4u.standard.OAuth2.Adal/Arc4u.Standard.OAuth2.Adal.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>Arc4u.OAuth2</RootNamespace>
     <AssemblyName>Arc4u.Standard.OAuth2.Adal</AssemblyName>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
@@ -19,9 +19,16 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>	
   </PropertyGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
+  </ItemGroup>
+    
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.9" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">


### PR DESCRIPTION
With the release of .NET Core 3.0, many ASP.NET Core assemblies are no longer published to NuGet as packages. Instead, the assemblies are included in the Microsoft.AspNetCore.App shared framework, which is installed with the .NET Core SDK and runtime installers.

Reference
https://docs.microsoft.com/en-us/aspnet/core/fundamentals/target-aspnetcore?view=aspnetcore-5.0&tabs=visual-studio