### PR TITLE
feat: Add support to pass MongoClientSettings as a parameter of Creat…

### DIFF
--- a/src/Arc4u.Standard.MongoDB/IMongoClientFactory.cs
+++ b/src/Arc4u.Standard.MongoDB/IMongoClientFactory.cs
@@ -9,9 +9,10 @@ namespace Arc4u.MongoDB
     {
         IMongoClient CreateClient();
 
+        IMongoClient CreateClient(MongoClientSettings mongoClientSettings);
+
         IMongoCollection<TEntity> GetCollection<TEntity>(string collectionName);
 
         IMongoCollection<TEntity> GetCollection<TEntity>();
     }
-
 }


### PR DESCRIPTION
Ability to pass the `MongoClientSettings` as a parameter of `CreateClient`. There are advanced features to be used in Diagnostics (Optl) and OData Linq manipulation, which goes beyond of settings in a config file. 