### PR TITLE
Improve NuGet packages configuration

### DIFF
--- a/src/Arc4u.Prism.DI.Wpf/Arc4u.Prism.DI.Wpf.csproj
+++ b/src/Arc4u.Prism.DI.Wpf/Arc4u.Prism.DI.Wpf.csproj
@@ -24,8 +24,6 @@
 		<Copyright>Gilles Flisch</Copyright>
 		<PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>
-		<IncludeSymbols>true</IncludeSymbols>
-		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 		<PackageLicenseExpression></PackageLicenseExpression>
 		<PackageTags>Arc4u</PackageTags>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Arc4u.Standard.Diagnostics.Serilog.Sinks.RealmDb/Arc4u.Standard.Diagnostics.Serilog.Sinks.RealmDb.csproj
+++ b/src/Arc4u.Standard.Diagnostics.Serilog.Sinks.RealmDb/Arc4u.Standard.Diagnostics.Serilog.Sinks.RealmDb.csproj
@@ -27,16 +27,6 @@
 		<LangVersion>latest</LangVersion>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-		<DebugType>full</DebugType>
-		<DebugSymbols>True</DebugSymbols>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-		<DebugType>full</DebugType>
-		<DebugSymbols>True</DebugSymbols>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<PackageReference Include="AutoMapper" Version="11.0.1" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">

--- a/src/Arc4u.Standard.NServiceBus.Core/Arc4u.Standard.NServiceBus.Core.csproj
+++ b/src/Arc4u.Standard.NServiceBus.Core/Arc4u.Standard.NServiceBus.Core.csproj
@@ -13,8 +13,6 @@
 		<Copyright>Gilles Flisch</Copyright>
 		<PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>
-		<IncludeSymbols>true</IncludeSymbols>
-		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 		<PackageLicenseExpression></PackageLicenseExpression>
 		<PackageTags>Arc4u</PackageTags>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Arc4u.Standard.OAuth2.Client/Arc4u.Standard.OAuth2.Client.csproj
+++ b/src/Arc4u.Standard.OAuth2.Client/Arc4u.Standard.OAuth2.Client.csproj
@@ -27,16 +27,6 @@
 		<LangVersion>latest</LangVersion>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-		<DebugType>full</DebugType>
-		<DebugSymbols>True</DebugSymbols>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-		<DebugType>full</DebugType>
-		<DebugSymbols>True</DebugSymbols>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
 			<PrivateAssets>all</PrivateAssets>

--- a/src/Arc4u.Standard/Arc4u.Standard.csproj
+++ b/src/Arc4u.Standard/Arc4u.Standard.csproj
@@ -20,23 +20,11 @@
 		<Copyright>Gilles Flisch</Copyright>
 		<PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>
-		<IncludeSymbols>true</IncludeSymbols>
-		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 		<PackageLicenseExpression></PackageLicenseExpression>
 		<PackageTags>Arc4u</PackageTags>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
 		<LangVersion>latest</LangVersion>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-		<DebugType>full</DebugType>
-		<DebugSymbols>True</DebugSymbols>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-		<DebugType>full</DebugType>
-		<DebugSymbols>True</DebugSymbols>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,33 @@
+<Project>
+  <PropertyGroup>
+    <RepositoryType>git</RepositoryType>
+    <!-- disable warning when XML comments are missing -->
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <!-- By default every projects are packable -->
+    <IsPackable>true</IsPackable>
+    <!-- But unit test project are not. -->
+    <IsPackable Condition="$(MSBuildProjectName.EndsWith('Test'))">false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)'=='Release' AND $(IsPackable) == true">
+    <!-- Produce a NuGet package upon build.-->
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <!-- Publish the repository URL in the built .nupkg -->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <!-- Embed source files that are not tracked by the source control manager in the PDB -->
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <!-- Embed symbols containing Source Link in the main file (exe/dll) -->
+    <DebugType>embedded</DebugType>
+    <!-- Ensure that pdb's can be added to nuget packages -->
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  
+  <!-- Always set to true when GitHub Actions is running the workflow -->
+  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+
+</Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release' AND $(IsPackable) == true">
-    <!-- Produce a NuGet package upon build.-->
+    <!-- Produce a NuGet package upon build -->
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <!-- Publish the repository URL in the built .nupkg -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>


### PR DESCRIPTION
This PR improves the configuration of NuGet packages:
- Documentation get exported.
- Source link and pbd are correctly integrated.
- Deterministic builds are enabled.

To do so, a  Directory.Build.prop file has been introduced.
This makes every csproj inherit from the configuration specified in it.
This is very handy and common use to apply same configuration on multiple projects / NuGet.
Comments have been added in the file to bring more explanation.

Currently the configuration of Arc4 NuGet produces the following : 
![image](https://user-images.githubusercontent.com/6811304/188326375-baf1b353-5903-4ed6-b7d7-b0e35e89f079.png)

With this PR.
![image](https://user-images.githubusercontent.com/6811304/188326529-e2fddc21-60b0-4121-a5a3-89e782f2606c.png)

# <!> Note:
few other improvements can be brought such centralyzing configuration such:
```xml
<Authors>Gilles Flisch</Authors>
<Company>Gilles Flisch</Company>
etc ...
```

Enabling export of XML documentation enable  [CS1591](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs1591) which raises a warning for each public property/method/etc not documented.