### PR TITLE
Framework code quality  update

### DIFF
--- a/src/Arc4u.Prism.DI.Wpf/Ioc/DIContainerExtension.cs
+++ b/src/Arc4u.Prism.DI.Wpf/Ioc/DIContainerExtension.cs
@@ -20,17 +20,17 @@ namespace Prism.DI.Ioc
 
         public abstract void FinalizeExtension();
 
-        public object Resolve(Type type)
+        public object? Resolve(Type type)
         {
             return Container?.Resolve(type);
         }
 
-        public object Resolve(Type type, string name)
+        public object? Resolve(Type type, string name)
         {
             return Container?.Resolve(type, name);
         }
 
-        public object ResolveViewModelForView(object view, Type viewModelType)
+        public object? ResolveViewModelForView(object view, Type viewModelType)
         {
             return Container?.Resolve(viewModelType);
         }

--- a/src/Arc4u.Standard.OAuth.Msal/TokenProvider/Client/MsalTokenProvider.cs
+++ b/src/Arc4u.Standard.OAuth.Msal/TokenProvider/Client/MsalTokenProvider.cs
@@ -89,7 +89,7 @@ namespace Arc4u.OAuth2.Msal.TokenProvider.Client
                     _logger.Technical().Exception(msalex).Log();
                 }
             }
-            catch (Exception ex)
+            catch
             {
                 return null;
             }

--- a/src/Arc4u.Standard.OAuth.Msal/TokenProvider/Client/PublicClientApp.cs
+++ b/src/Arc4u.Standard.OAuth.Msal/TokenProvider/Client/PublicClientApp.cs
@@ -8,7 +8,7 @@ namespace Arc4u.OAuth2.Msal.TokenProvider.Client
     [Export, Shared]
     public class PublicClientApp
     {
-        public IPublicClientApplication? PublicClient { get; set; }
+        public IPublicClientApplication PublicClient { get; set; }
 
         public void SetCustomWebUi(Func<ICustomWebUi> customWebUi)
         {
@@ -16,7 +16,7 @@ namespace Arc4u.OAuth2.Msal.TokenProvider.Client
         }
         private Func<ICustomWebUi> _customWebUi;
        
-        public ICustomWebUi? CustomWebUi => HasCustomWebUi ? _customWebUi() : null;
+        public ICustomWebUi CustomWebUi => HasCustomWebUi ? _customWebUi() : null;
 
         public bool HasCustomWebUi => _customWebUi is not null;
     }

--- a/src/Arc4u.Standard.OAuth2.AspNetCore.Adal/TokenProvider/Obo/OboClientTokenProvider.cs
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore.Adal/TokenProvider/Obo/OboClientTokenProvider.cs
@@ -65,7 +65,7 @@ namespace Arc4u.OAuth2.TokenProvider
             {
                 _logger.Technical().Exception(ex).Log();
 
-                throw ex;
+                throw;
             }
 
             throw new ApplicationException("No token could be retrieve");

--- a/src/Arc4u.Standard.OAuth2/TokenProvider/ClientSecretTokenProvider.cs
+++ b/src/Arc4u.Standard.OAuth2/TokenProvider/ClientSecretTokenProvider.cs
@@ -174,7 +174,7 @@ namespace Arc4u.OAuth2.TokenProvider
 
             return new CredentialsResult(true, username, pwd);
         }
-        protected async Task<TokenInfo> CreateBasicTokenInfoAsync(IKeyValueSettings settings, CredentialsResult credential)
+        private async Task<TokenInfo> CreateBasicTokenInfoAsync(IKeyValueSettings settings, CredentialsResult credential)
         {
             var basicTokenProvider = _container.Resolve<ICredentialTokenProvider>(CredentialTokenProvider.ProviderName);
 

--- a/src/Arc4u.Standard.OAuth2/TokenProvider/CredentialTokenProvider.cs
+++ b/src/Arc4u.Standard.OAuth2/TokenProvider/CredentialTokenProvider.cs
@@ -110,7 +110,7 @@ namespace Arc4u.OAuth2.TokenProvider
 
                     using (var response = await client.PostAsync(authority + "/oauth2/token", content).ConfigureAwait(true))
                     {
-                        var responseBody = response.Content.ReadAsStringAsync().Result;
+                        var responseBody = await response.Content.ReadAsStringAsync();
 
                         if (response.StatusCode == HttpStatusCode.BadRequest)
                         {

--- a/src/Arc4u.Standard.UnitTest/Infrastructure/BaseContainerFixture.cs
+++ b/src/Arc4u.Standard.UnitTest/Infrastructure/BaseContainerFixture.cs
@@ -11,7 +11,7 @@ namespace Arc4u.Standard.UnitTest.Infrastructure
         protected readonly IContainerFixture _containerFixture;
         private readonly ILogger<T> _logger;
 
-        public BaseContainerFixture(TFixture? containerFixture)
+        public BaseContainerFixture(TFixture containerFixture)
         {
             _containerFixture = containerFixture;
             _logger = containerFixture.SharedContainer.Resolve<ILogger<T>>();

--- a/src/Arc4u.Standard.UnitTest/KubeMQ/KubeMQFundamentals.cs
+++ b/src/Arc4u.Standard.UnitTest/KubeMQ/KubeMQFundamentals.cs
@@ -132,7 +132,7 @@ namespace Arc4u.Standard.UnitTest.KubeMQ
                 {
                     try
                     {
-                        Assert.Equal(1, msg.Tags.Count());
+                        Assert.Single(msg.Tags);
 
                         Assert.True(Guid.TryParse(Encoding.UTF8.GetString(msg.Body), out var guid));
 
@@ -202,7 +202,7 @@ namespace Arc4u.Standard.UnitTest.KubeMQ
                 {
                     try
                     {
-                        Assert.Equal(1, msg.Tags.Count());
+                        Assert.Single(msg.Tags);
 
                         Assert.True(Guid.TryParse(Encoding.UTF8.GetString(msg.Body), out var guid));
 
@@ -313,7 +313,7 @@ namespace Arc4u.Standard.UnitTest.KubeMQ
                 {
                     try
                     {
-                        Assert.Equal(1, msg.Tags.Count());
+                        Assert.Single(msg.Tags);
 
                         Assert.True(Guid.TryParse(Encoding.UTF8.GetString(msg.Body), out var guid));
                         await Task.Delay(100);

--- a/src/Arc4u.Standard.UnitTest/Logging/BaseSinkContainerFixture.cs
+++ b/src/Arc4u.Standard.UnitTest/Logging/BaseSinkContainerFixture.cs
@@ -11,7 +11,7 @@ namespace Arc4u.Standard.UnitTest.Logging
         protected readonly ISinkContainerFixture _containerFixture;
         private readonly ILogger<T> _logger;
 
-        public BaseSinkContainerFixture(TFixture? containerFixture)
+        public BaseSinkContainerFixture(TFixture containerFixture)
         {
             _containerFixture = containerFixture;
             _logger = containerFixture.SharedContainer.Resolve<ILogger<T>>();

--- a/src/Arc4u.Standard.UnitTest/Logging/SerilogTests.cs
+++ b/src/Arc4u.Standard.UnitTest/Logging/SerilogTests.cs
@@ -90,11 +90,11 @@ public class SerilogTests : BaseContainerFixture<SerilogTests, BasicFixture>
 
             using (new LoggerContext())
             {
-                Assert.Equal((int)(LoggerContext.Current.All().First(kv => kv.Key.Equals("Code")).Value), (long)100);
+                Assert.Equal(100, (int)(LoggerContext.Current.All().First(kv => kv.Key.Equals("Code")).Value));
                 LoggerContext.Current.Add("Code2", 101);
                 LoggerContext.Current.Add("Code", 101);
                 Assert.Contains(LoggerContext.Current.All(), kv => kv.Key.Equals("Code2"));
-                Assert.Equal((int)(LoggerContext.Current.All().First(kv => kv.Key.Equals("Code2")).Value), (long)101);
+                Assert.Equal(101, (int)(LoggerContext.Current.All().First(kv => kv.Key.Equals("Code2")).Value));
                 Assert.Contains(LoggerContext.Current.All(), kv => kv.Key.Equals("Code"));
             }
             Assert.DoesNotContain(LoggerContext.Current.All(), kv => kv.Key.Equals("Code2"));

--- a/src/Arc4u.Standard.gRPC/ChannelCertificate/RootPemCertificates.cs
+++ b/src/Arc4u.Standard.gRPC/ChannelCertificate/RootPemCertificates.cs
@@ -18,6 +18,7 @@ namespace Arc4u.gRPC.ChannelCertificate
             _certificateExtractor = certificateExtractor;
 
             PemsCollections = new Dictionary<string, string>();
+            _logger = logger;
         }
 
         readonly IRootCertificateExtractor _certificateExtractor;

--- a/src/Arc4u.Standard/Exceptions/AppException.cs
+++ b/src/Arc4u.Standard/Exceptions/AppException.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace Arc4u
 {
@@ -91,10 +92,8 @@ namespace Arc4u
 
         }
 
-        public static void ProcessAppException(HttpResponseMessage exception)
+        private static void ProcessAppExceptionContent(string content)
         {
-            var content = exception.Content.ReadAsStringAsync().Result;
-
             IEnumerable<Message> messages = null;
             try
             {
@@ -109,6 +108,18 @@ namespace Arc4u
             }
 
             throw new AppException(messages);
+        }
+
+        public static async Task ProcessAppExceptionAsync(HttpResponseMessage exception)
+        {
+            var content = await exception.Content.ReadAsStringAsync();
+            ProcessAppExceptionContent(content);
+        }
+
+        public static void ProcessAppException(HttpResponseMessage exception)
+        {
+            var content = exception.Content.ReadAsStringAsync().Result;
+            ProcessAppExceptionContent(content);
         }
     }
 }


### PR DESCRIPTION
- Eliminate all warnings from building the framework.
- Keep stack trace when exceptions are rethrown in `GetTokenAsync` of https://github.com/GFlisch/Arc4u/blob/master/src/Arc4u.Standard.OAuth.Msal/TokenProvider/Client/MsalTokenProvider.cs
- Corrected bug in `RootPemCertificates` (https://github.com/GFlisch/Arc4u/blob/master/src/Arc4u.Standard.gRPC/ChannelCertificate/RootPemCertificates.cs) in which the `_logger` was not properly initialized causing any error in fetching or converting the certificate to crash instead of logging the error.
- Changed synchronous call to asynchronous call in `ClientCredentialTokenProvider`. This addresses issue #35.
- Added method for asynchronous `AppException` processing. This addresses #34.