### PR TITLE
More Quality updates

### DIFF
--- a/src/Arc4u.Standard.Configuration/AppSettings.cs
+++ b/src/Arc4u.Standard.Configuration/AppSettings.cs
@@ -1,20 +1,15 @@
-﻿using Arc4u.Dependency.Attribute;
+﻿using Arc4u.Configuration;
+using Arc4u.Dependency.Attribute;
 using Microsoft.Extensions.Configuration;
-using System;
-using System.Collections.Generic;
 
 namespace Arc4u
 {
     [Export(typeof(IAppSettings)), Shared]
-    public sealed class AppSettings : IAppSettings
+    public sealed class AppSettings : KeyValueSettings, IAppSettings
     {
         public AppSettings(IConfiguration configuration)
+            :base("AppSettings", configuration)
         {
-            Properties = configuration.GetSection("AppSettings").Get<Dictionary<String, String>>() ?? new Dictionary<string, string>();
         }
-
-        private Dictionary<String, String> Properties { get; }
-
-        public IReadOnlyDictionary<string, string> Values => Properties;
     }
 }

--- a/src/Arc4u.Standard.Configuration/Configuration/ConfigurationHelper.cs
+++ b/src/Arc4u.Standard.Configuration/Configuration/ConfigurationHelper.cs
@@ -6,7 +6,7 @@ using System.Reflection;
 
 namespace Arc4u.Configuration
 {
-    public class ConfigurationHelper
+    public static class ConfigurationHelper
     {
         /// <summary>
         /// Load json files for the configuration and returns a IConfiguration so we can extract the

--- a/src/Arc4u.Standard.Core/Arc4u.Standard.Core.csproj
+++ b/src/Arc4u.Standard.Core/Arc4u.Standard.Core.csproj
@@ -22,9 +22,6 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Arc4u.Standard.Data/Data/IdEntity!1.cs
+++ b/src/Arc4u.Standard.Data/Data/IdEntity!1.cs
@@ -96,7 +96,7 @@ namespace Arc4u.Data
         /// </returns>
         public override int GetHashCode()
         {
-            return object.Equals(Id, default(TId)) ? 0 : Id.GetHashCode();
+            return Id?.GetHashCode() ?? 0;
         }
 
         /// <summary>
@@ -106,9 +106,7 @@ namespace Arc4u.Data
         /// <returns><c>true</c> if the specified <see cref="Object"/> is equal to the current <see cref="Object"/> ; otherwise, <c>false</c>.</returns>
         public override bool Equals(object obj)
         {
-            return (obj is IdEntity<TId>)
-                ? Equals((IdEntity<TId>)obj)
-                : false;
+            return obj is IdEntity<TId> other && Equals(other);
         }
 
         /// <summary>

--- a/src/Arc4u.Standard.KubeMQ.AspNetCore/Arc4u.Standard.KubeMQ.AspNetCore.csproj
+++ b/src/Arc4u.Standard.KubeMQ.AspNetCore/Arc4u.Standard.KubeMQ.AspNetCore.csproj
@@ -26,6 +26,7 @@
 	<ItemGroup>
 		<ProjectReference Include="..\Arc4u.Standard.Diagnostics\Arc4u.Standard.Diagnostics.csproj" />
 		<ProjectReference Include="..\Arc4u.Standard.KubeMQ\Arc4u.Standard.KubeMQ.csproj" />
+		<ProjectReference Include="..\Arc4u.Standard.Serializer\Arc4u.Standard.Serializer.csproj" />
 		<ProjectReference Include="..\Arc4u.Standard\Arc4u.Standard.csproj" />
 	</ItemGroup>
 

--- a/src/Arc4u.Standard.KubeMQ.AspNetCore/Queues/Listener/DefaultUniqueness.cs
+++ b/src/Arc4u.Standard.KubeMQ.AspNetCore/Queues/Listener/DefaultUniqueness.cs
@@ -6,7 +6,7 @@ using System.Linq;
 
 namespace Arc4u.KubeMQ.AspNetCore.Queues
 {
-    public class DefaultUniqueness : IUniqueness, IEqualityComparer<QueueParameters>
+    public class DefaultUniqueness : IUniqueness
     {
         public DefaultUniqueness(IEnumerable<QueueParameters> queueParameters)
         {
@@ -17,11 +17,18 @@ namespace Arc4u.KubeMQ.AspNetCore.Queues
 
         public IEnumerable<QueueParameters> GetQueues()
         {
-            return _queueParameters.Distinct(this);
+            return _queueParameters.Distinct(QueueParametersEqualityComparer.Default);
         }
+    }
+
+    public class QueueParametersEqualityComparer: IEqualityComparer<QueueParameters>
+    {
+        public static readonly QueueParametersEqualityComparer Default = new();
 
         public bool Equals(QueueParameters x, QueueParameters y)
         {
+            if (x == null || y == null)
+                return x == null && y == null;
             return x.Namespace.Equals(y.Namespace, StringComparison.InvariantCultureIgnoreCase) &&
                    x.Address.Equals(y.Address, StringComparison.InvariantCultureIgnoreCase);
         }

--- a/src/Arc4u.Standard.UnitTest/Infrastructure/MemorySetting.cs
+++ b/src/Arc4u.Standard.UnitTest/Infrastructure/MemorySetting.cs
@@ -1,20 +1,14 @@
 ﻿using Arc4u.Caching.Memory;
+using Arc4u.Configuration;
 using System.Collections.Generic;
 
 namespace Arc4u.Standard.UnitTest.Infrastructure
 {
-    class MemorySettings : IKeyValueSettings
+    class MemorySettings : SimpleKeyValueSettings
     {
         public MemorySettings()
+            :base(new Dictionary<string, string> { { MemoryCache.CompactionPercentageKey, "0.2" }, { MemoryCache.SizeLimitKey, "100000" } })
         {
-            _values = new Dictionary<string, string>();
-            _values.Add(MemoryCache.CompactionPercentageKey, "0.2");
-            _values.Add(MemoryCache.SizeLimitKey, "100000");
         }
-
-        private Dictionary<string, string> _values;
-
-        public IReadOnlyDictionary<string, string> Values => _values;
-
     }
 }

--- a/src/Arc4u.Standard/Arc4u.Standard.csproj
+++ b/src/Arc4u.Standard/Arc4u.Standard.csproj
@@ -42,12 +42,10 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
 		<PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="..\Arc4u.Standard.Caching\Arc4u.Standard.Caching.csproj" />
 		<ProjectReference Include="..\Arc4u.Standard.Configuration\Arc4u.Standard.Configuration.csproj" />
 		<ProjectReference Include="..\Arc4u.Standard.Core\Arc4u.Standard.Core.csproj" />
 		<ProjectReference Include="..\Arc4u.Standard.Dependency\Arc4u.Standard.Dependency.csproj" />

--- a/src/Arc4u.Standard/Bound!1.cs
+++ b/src/Arc4u.Standard/Bound!1.cs
@@ -170,11 +170,15 @@ namespace Arc4u
         /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode()
         {
+#if NETSTANDARD2_1_OR_GREATER
+            return HashCode.Combine(Type, Direction, Value);
+#else
             int hash = 0x4043ed47;
             hash = (hash * -1521134295) + Type.GetHashCode();
             hash = (hash * -1521134295) + Direction.GetHashCode();
             hash = (hash * -1521134295) + (object.Equals(Value, default(T)) ? 0 : Value.GetHashCode());
             return hash;
+#endif
         }
 
         /// <summary>
@@ -191,9 +195,9 @@ namespace Arc4u
                 : false;
         }
 
-        #endregion
+#endregion
 
-        #region IEquatable<Bound<T>> Members
+#region IEquatable<Bound<T>> Members
 
         /// <summary>
         /// Returns a value indicating whether this instance is equal to a specified <see cref="Bound&lt;T&gt;"/>.
@@ -211,9 +215,9 @@ namespace Arc4u
                 && object.Equals(Value, other.Value));
         }
 
-        #endregion
+#endregion
 
-        #region IComparable<Bound<T>> Members
+#region IComparable<Bound<T>> Members
 
         /// <summary>
         /// Compares this instance to a specified <see cref="Bound&lt;T&gt;"/> and returns an indication of their relative values.
@@ -284,9 +288,9 @@ namespace Arc4u
                     : -1;
         }
 
-        #endregion
+#endregion
 
-        #region Methods
+#region Methods
 
         internal static void OverrideBounds(T lowestValue, T upmostValue)
         {
@@ -381,9 +385,9 @@ namespace Arc4u
                         : Comparer<T>.Default.Compare(Value, value) > 0;
         }
 
-        #endregion
+#endregion
 
-        #region Operators
+#region Operators
 
         /// <summary>
         /// Implements the operator ==.
@@ -463,6 +467,6 @@ namespace Arc4u
             return (left.CompareTo(right) >= 0);
         }
 
-        #endregion
+#endregion
     }
 }

--- a/src/Arc4u.Standard/Interval!1.cs
+++ b/src/Arc4u.Standard/Interval!1.cs
@@ -211,10 +211,14 @@ namespace Arc4u
         /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode()
         {
+#if NETSTANDARD2_1_OR_GREATER
+            return HashCode.Combine(LowerBound, UpperBound);
+#else
             int hash = 0x4043ed47;
             hash = (hash * -1521134295) + (object.Equals(LowerBound, default(Bound<T>)) ? 0 : LowerBound.GetHashCode());
             hash = (hash * -1521134295) + (object.Equals(UpperBound, default(Bound<T>)) ? 0 : UpperBound.GetHashCode());
             return hash;
+#endif
         }
 
         /// <summary>
@@ -226,14 +230,12 @@ namespace Arc4u
         /// </returns>
         public override bool Equals(object obj)
         {
-            return (obj is Interval<T>)
-            ? Equals((Interval<T>)obj)
-            : false;
+            return obj is Interval<T> other && Equals(other);
         }
 
-        #endregion
+#endregion
 
-        #region IEquatable<Interval<T>> Members
+#region IEquatable<Interval<T>> Members
 
         /// <summary>
         /// Returns a value indicating whether this instance is equal to a specified <see cref="Interval&lt;T&gt;"/>.
@@ -250,9 +252,9 @@ namespace Arc4u
                 && UpperBound.Equals(other.UpperBound));
         }
 
-        #endregion
+#endregion
 
-        #region IComparable<Interval<T>> Members
+#region IComparable<Interval<T>> Members
 
         /// <summary>
         /// Compares this instance to a specified <see cref="Interval&lt;T&gt;"/> and returns an indication of their relative values.
@@ -299,9 +301,9 @@ namespace Arc4u
                 : LowerBound.CompareTo(other.LowerBound);
         }
 
-        #endregion
+#endregion
 
-        #region Operators
+#region Operators
 
         /// <summary>
         /// Implements the operator ==.
@@ -369,9 +371,9 @@ namespace Arc4u
             return left != (right as Interval<T>);
         }
 
-        #endregion
+#endregion
 
-        #region Methods
+#region Methods
 
         /// <summary>
         /// Overrides the default bound values of <see cref="Interval&lt;T&gt;"/>.
@@ -521,6 +523,6 @@ namespace Arc4u
             return Interval.DifferenceOf(this, other);
         }
 
-        #endregion       
+#endregion
     }
 }


### PR DESCRIPTION
- Implementations of `GetHashCode()` now use `HashCode` class and `Combine` methods for .NET Standard 2.1+ instead of custom-made algorithms.
- `Arc4u.Standard.csproj` contained useless references to `Arc4u.Standard.Caching and `Microsoft.CSharp`, which have been removed
- `ConfigurationHelper` contains all static methods and is therefore a static class
- `SimpleKeyValueSettings` equality comparison is now correct, as outlined in https://github.com/GFlisch/Arc4u.Guidance.Doc/issues/78
- `AppSettings` and `MemorySettings` behave like `SimpleKeyValueSettings` and therefore now derive from it.
- 'DefaultUniquness` is refactored according to https://github.com/GFlisch/Arc4u.Guidance.Doc/issues/81