### PR TITLE
Conversions of numbers from configuration files must be insensitive to culture settings

### DIFF
--- a/src/Arc4u.Standard.Caching.Memory/MemoryCache.cs
+++ b/src/Arc4u.Standard.Caching.Memory/MemoryCache.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using System;
+using System.Globalization;
 
 namespace Arc4u.Caching.Memory
 {
@@ -40,13 +41,13 @@ namespace Arc4u.Caching.Memory
                 {
                     if (settings.Values.ContainsKey(CompactionPercentageKey))
                     {
-                        if (Double.TryParse(settings.Values[CompactionPercentageKey], out var percentage))
+                        if (Double.TryParse(settings.Values[CompactionPercentageKey], NumberStyles.Integer, CultureInfo.InvariantCulture, out var percentage))
                             CompactionPercentage = percentage / 100;
                     }
 
                     if (settings.Values.ContainsKey(SizeLimitKey))
                     {
-                        if (long.TryParse(settings.Values[SizeLimitKey], out var size))
+                        if (long.TryParse(settings.Values[SizeLimitKey], NumberStyles.Integer, CultureInfo.InvariantCulture, out var size))
                             SizeLimit = size * 1024 * 1024;
                     }
 

--- a/src/Arc4u.Standard.Diagnostics.TraceListeners/FileLoggerTraceListener.cs
+++ b/src/Arc4u.Standard.Diagnostics.TraceListeners/FileLoggerTraceListener.cs
@@ -252,7 +252,7 @@ namespace Arc4u.Diagnostics
             var result = 10; // default is 10 days.
             if (AttributesCopy.ContainsKey(MaxFileDaysKey))
             {
-                int.TryParse(AttributesCopy[MaxFileDaysKey], out result);
+                int.TryParse(AttributesCopy[MaxFileDaysKey], NumberStyles.Integer, CultureInfo.InvariantCulture, out result);
             }
 
             return result;
@@ -274,7 +274,7 @@ namespace Arc4u.Diagnostics
             long result = 10 * 1024 * 2014; // default is 10 MBytes.
             if (AttributesCopy.ContainsKey(MaxFileSizeKey))
             {
-                if (long.TryParse(AttributesCopy[MaxFileSizeKey], out result))
+                if (long.TryParse(AttributesCopy[MaxFileSizeKey], NumberStyles.Integer, CultureInfo.InvariantCulture, out result))
                 {
                     if (result > max) result = max;
                     else

--- a/src/Arc4u.Standard.Diagnostics.TraceListeners/TracelistenerEx.cs
+++ b/src/Arc4u.Standard.Diagnostics.TraceListeners/TracelistenerEx.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Globalization;
 using System.IO;
 using System.Runtime.Serialization;
 using System.Threading;
@@ -196,7 +197,7 @@ namespace Arc4u.Diagnostics
             var result = 10; // default is 10 days.
             if (AttributesCopy.ContainsKey(MaxFileDaysKey))
             {
-                int.TryParse(AttributesCopy[MaxFileDaysKey], out result);
+                int.TryParse(AttributesCopy[MaxFileDaysKey], NumberStyles.Integer, CultureInfo.InvariantCulture, out result);
             }
 
             return result;
@@ -207,7 +208,7 @@ namespace Arc4u.Diagnostics
             TimeSpan result = TimeSpan.FromSeconds(10); // default is 10 seconds.
             if (AttributesCopy.ContainsKey(FrequencyKey))
             {
-                TimeSpan.TryParse(AttributesCopy[FrequencyKey], out result);
+                TimeSpan.TryParse(AttributesCopy[FrequencyKey], CultureInfo.InvariantCulture, out result);
                 if (TimeSpan.Zero == result)
                     result = TimeSpan.FromSeconds(10);
             }

--- a/src/Arc4u.Standard.OAuth2.AspNetCore/Middleware/ClaimsPrincipalMiddleware.cs
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore/Middleware/ClaimsPrincipalMiddleware.cs
@@ -203,7 +203,7 @@ namespace Arc4u.Standard.OAuth2.Middleware
                 var cachedExpiredClaim = cachedClaims.FirstOrDefault(c => c.ClaimType.Equals(tokenExpirationClaimType, StringComparison.InvariantCultureIgnoreCase));
                 long cachedExpiredTicks = 0;
 
-                if (null != cachedExpiredClaim && long.TryParse(cachedExpiredClaim.Value, out cachedExpiredTicks))
+                if (null != cachedExpiredClaim && long.TryParse(cachedExpiredClaim.Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out cachedExpiredTicks))
                 {
                     var expDate = DateTimeOffset.FromUnixTimeSeconds(cachedExpiredTicks).UtcDateTime;
                     if (expDate > DateTime.UtcNow)

--- a/src/Arc4u.Standard.OAuth2.Client/Security/Principal/AppPrincipalFactory.cs
+++ b/src/Arc4u.Standard.OAuth2.Client/Security/Principal/AppPrincipalFactory.cs
@@ -10,6 +10,7 @@ using Arc4u.ServiceModel;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Security.Claims;
@@ -129,7 +130,7 @@ namespace Arc4u.OAuth2.Client.Security.Principal
                 var expTokenClaim = jwtToken.Claims.FirstOrDefault(c => c.Type.Equals(tokenExpirationClaimType, StringComparison.InvariantCultureIgnoreCase));
                 long expTokenTicks = 0;
                 if (null != expTokenClaim)
-                    long.TryParse(expTokenClaim.Value, out expTokenTicks);
+                    long.TryParse(expTokenClaim.Value, NumberStyles.Integer, CultureInfo.InvariantCulture,  out expTokenTicks);
 
                 Identity.BootstrapContext = token.AccessToken;
 
@@ -143,7 +144,7 @@ namespace Arc4u.OAuth2.Client.Security.Principal
                 long cachedExpiredTicks = 0;
 
                 if (null != cachedExpiredClaim)
-                    long.TryParse(cachedExpiredClaim.Value, out cachedExpiredTicks);
+                    long.TryParse(cachedExpiredClaim.Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out cachedExpiredTicks);
 
                 // we only call the backend if the ticks are not the same.
                 copyClaimsFromCache = cachedExpiredTicks > 0 && expTokenTicks > 0 && cachedClaims.Count > 0 && cachedExpiredTicks == expTokenTicks;

--- a/src/Arc4u.Standard.OAuth2/Token/UserProfileExt.cs
+++ b/src/Arc4u.Standard.OAuth2/Token/UserProfileExt.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Linq;
 using System.Security.Claims;
 using System.Security.Principal;
@@ -27,7 +28,7 @@ namespace Arc4u.OAuth2.Token
                 long expTokenTicks = 0;
                 if (null != expTokenClaim)
                 {
-                    long.TryParse(expTokenClaim.Value, out expTokenTicks);
+                    long.TryParse(expTokenClaim.Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out expTokenTicks);
 
                     return DateTimeOffset.FromUnixTimeSeconds(expTokenTicks);
                 }

--- a/src/Arc4u.Standard.OAuth2/TokenProvider/CredentialTokenProvider.cs
+++ b/src/Arc4u.Standard.OAuth2/TokenProvider/CredentialTokenProvider.cs
@@ -8,6 +8,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -154,7 +155,7 @@ namespace Arc4u.OAuth2.TokenProvider
                         var expiresIn = responseValues["expires_in"];
 
                         // expires in is in ms.
-                        Int64.TryParse(expiresIn, out var offset);
+                        Int64.TryParse(expiresIn, NumberStyles.Integer, CultureInfo.InvariantCulture, out var offset);
                         var dateUtc = DateTime.UtcNow.AddSeconds(offset);
 
                         _logger.Technical().System($"Access token will expire at {dateUtc} utc.").Log();

--- a/src/Arc4u.Standard.Serializer.Protobuf/TypeReconstructor.cs
+++ b/src/Arc4u.Standard.Serializer.Protobuf/TypeReconstructor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Reflection;
 using System.Text.RegularExpressions;
 
@@ -63,7 +64,7 @@ namespace Arc4u.Serializer.ProtoBuf
                     throw new Exception($"Unable to parse the type's assembly qualified name: {assemblyQualifiedName}");
 
             var typeName = match.Groups["name"].Value;
-            int n = int.Parse(match.Groups["count"].Value);
+            int n = int.Parse(match.Groups["count"].Value, CultureInfo.InvariantCulture);
             //var assemblyName = match.Groups["assembly"].Value;
             var subtypes = match.Groups["subtypes"].Value;
 

--- a/src/Arc4u.Standard.Serializer.ProtobufV2/TypeReconstructor.cs
+++ b/src/Arc4u.Standard.Serializer.ProtobufV2/TypeReconstructor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Reflection;
 using System.Text.RegularExpressions;
 
@@ -63,7 +64,7 @@ namespace Arc4u.Serializer.ProtoBuf
                     throw new Exception($"Unable to parse the type's assembly qualified name: {assemblyQualifiedName}");
 
             var typeName = match.Groups["name"].Value;
-            int n = int.Parse(match.Groups["count"].Value);
+            int n = int.Parse(match.Groups["count"].Value, CultureInfo.InvariantCulture);
             //var assemblyName = match.Groups["assembly"].Value;
             var subtypes = match.Groups["subtypes"].Value;
 


### PR DESCRIPTION
It is good practice that numbers (and other information whose formatting is culture-sensitive) from configuration settings are interpreted in the invariant culture. Otherwise, their interpretation would depend on whatever language settings are associated with the service user.

This PR adds invariant culture information in those places where it was needed.

Note that there is parsing in [Enum.cs](https://github.com/GFlisch/Arc4u/blob/master/src/Arc4u.Standard/Utils/Enum.cs), but this file has not been touched pending the decision on https://github.com/GFlisch/Arc4u.Guidance.Doc/issues/79.