### PR TITLE
New exception handling (experimental)

### DIFF
--- a/src/Arc4u.Standard.Diagnostics.AspNetCore/Arc4u.Standard.Diagnostics.AspNetCore.csproj
+++ b/src/Arc4u.Standard.Diagnostics.AspNetCore/Arc4u.Standard.Diagnostics.AspNetCore.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Arc4u.Standard.Diagnostics\Arc4u.Standard.Diagnostics.csproj" />
+    <ProjectReference Include="..\Arc4u.Standard\Arc4u.Standard.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Arc4u.Standard.Diagnostics.AspNetCore/DefaultExceptionHandler.cs
+++ b/src/Arc4u.Standard.Diagnostics.AspNetCore/DefaultExceptionHandler.cs
@@ -2,7 +2,6 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using System;
-using System.Threading.Tasks;
 
 namespace Arc4u.Standard.Diagnostics.AspNetCore
 {
@@ -17,12 +16,12 @@ namespace Arc4u.Standard.Diagnostics.AspNetCore
         /// <param name="appException"></param>
         /// <param name="uid"></param>
         /// <returns></returns>
-        public static Task<(int StatusCode, object Value)> AppExceptionHandlerAsync(string path, AppException appException, Guid uid)
+        public static (int StatusCode, object Value) AppExceptionHandlerAsync(string path, AppException appException, Guid uid)
         {
             // it's too bad we need to include Arc4u.Standard just for Messages... Banana -> Gorilla
             var messages = Messages.FromEnum(appException.Messages);
             messages.LocalizeAll();
-            return Task.FromResult((StatusCodes.Status400BadRequest, (object)messages));
+            return (StatusCodes.Status400BadRequest, (object)messages);
         }
 
         /// <summary>
@@ -33,10 +32,10 @@ namespace Arc4u.Standard.Diagnostics.AspNetCore
         /// <param name="exception"></param>
         /// <param name="uid"></param>
         /// <returns></returns>
-        public static Task<(int StatusCode, object Value)> GenericExceptionHandlerAsync<TException>(string path, TException exception, Guid uid) where TException : Exception
+        public static (int StatusCode, object Value) GenericExceptionHandler<TException>(string path, TException exception, Guid uid) where TException : Exception
         {
             var problemDetails = CreateProblemDetails(path, exception, uid);
-            return Task.FromResult((problemDetails.Status.Value, (object)problemDetails));
+            return (problemDetails.Status.Value, (object)problemDetails);
         }
 
         /// <summary>
@@ -47,13 +46,13 @@ namespace Arc4u.Standard.Diagnostics.AspNetCore
         /// <param name="exception"></param>
         /// <param name="uid"></param>
         /// <returns></returns>
-        public static Task<(int StatusCode, object Value)> GenericExceptionHandlerWithDetailsAsync<TException>(string path, TException exception, Guid uid) where TException : Exception
+        public static (int StatusCode, object Value) GenericExceptionHandlerWithDetails<TException>(string path, TException exception, Guid uid) where TException : Exception
         {
             var problemDetails = CreateProblemDetails(path, exception, uid);
             var serializableValue = ExceptionPropertyValues.GetSerializable(exception);
             if (serializableValue is not null)
                 problemDetails.Extensions["ExceptionInstance"] = serializableValue;
-            return Task.FromResult((problemDetails.Status.Value, (object)problemDetails));
+            return (problemDetails.Status.Value, (object)problemDetails);
         }
 
 

--- a/src/Arc4u.Standard.Diagnostics.AspNetCore/DefaultExceptionHandler.cs
+++ b/src/Arc4u.Standard.Diagnostics.AspNetCore/DefaultExceptionHandler.cs
@@ -1,0 +1,79 @@
+﻿using Arc4u.ServiceModel;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Threading.Tasks;
+
+namespace Arc4u.Standard.Diagnostics.AspNetCore
+{
+    public static class DefaultExceptionHandler
+    {
+        public const string ExceptionUidKey = "ExceptionUid";
+
+        /// <summary>
+        /// The default handler for <see cref="AppException"/> to be compatible with the prvevious behavior
+        /// </summary>
+        /// <param name="path"></param>
+        /// <param name="appException"></param>
+        /// <param name="uid"></param>
+        /// <returns></returns>
+        public static Task<(int StatusCode, object Value)> AppExceptionHandlerAsync(string path, AppException appException, Guid uid)
+        {
+            // it's too bad we need to include Arc4u.Standard just for Messages... Banana -> Gorilla
+            var messages = Messages.FromEnum(appException.Messages);
+            messages.LocalizeAll();
+            return Task.FromResult((StatusCodes.Status400BadRequest, (object)messages));
+        }
+
+        /// <summary>
+        /// A default generic handler that returns problem details from exception information as outlined in https://tools.ietf.org/html/rfc7807.
+        /// </summary>
+        /// <typeparam name="TException"></typeparam>
+        /// <param name="path"></param>
+        /// <param name="exception"></param>
+        /// <param name="uid"></param>
+        /// <returns></returns>
+        public static Task<(int StatusCode, object Value)> GenericExceptionHandlerAsync<TException>(string path, TException exception, Guid uid) where TException : Exception
+        {
+            var problemDetails = CreateProblemDetails(path, exception, uid);
+            return Task.FromResult((problemDetails.Status.Value, (object)problemDetails));
+        }
+
+        /// <summary>
+        /// A default generic handler that returns problem details from exception information as outlined in https://tools.ietf.org/html/rfc7807.
+        /// </summary>
+        /// <typeparam name="TException"></typeparam>
+        /// <param name="path"></param>
+        /// <param name="exception"></param>
+        /// <param name="uid"></param>
+        /// <returns></returns>
+        public static Task<(int StatusCode, object Value)> GenericExceptionHandlerWithDetailsAsync<TException>(string path, TException exception, Guid uid) where TException : Exception
+        {
+            var problemDetails = CreateProblemDetails(path, exception, uid);
+            var serializableValue = ExceptionPropertyValues.GetSerializable(exception);
+            if (serializableValue is not null)
+                problemDetails.Extensions["ExceptionInstance"] = serializableValue;
+            return Task.FromResult((problemDetails.Status.Value, (object)problemDetails));
+        }
+
+
+        /// <summary>
+        /// Fill in the problem details with exception information
+        /// </summary>
+        /// <typeparam name="TException"></typeparam>
+        /// <param name="path"></param>
+        /// <param name="exception"></param>
+        /// <returns></returns>
+        private static ProblemDetails CreateProblemDetails<TException>(string path, TException exception, Guid uid) where TException : Exception
+        {
+            var problemDetails = new ProblemDetails
+            {
+                Title = exception.Message,
+                Status = StatusCodes.Status400BadRequest,
+                Instance = path,
+            };
+            problemDetails.Extensions[ExceptionUidKey] = uid;
+            return problemDetails;
+        }
+    }
+}

--- a/src/Arc4u.Standard.Diagnostics.AspNetCore/DynamicExceptionHandler.cs
+++ b/src/Arc4u.Standard.Diagnostics.AspNetCore/DynamicExceptionHandler.cs
@@ -1,0 +1,77 @@
+﻿using Arc4u.Diagnostics;
+using Arc4u.ServiceModel;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading.Tasks;
+
+namespace Arc4u.Standard.Diagnostics.AspNetCore
+{
+    /// <summary>
+    /// A handler for exceptions thrown by back-end methods.
+    /// This class is internal to this assembly, since it's an implementation detail.
+    /// </summary>
+    class DynamicExceptionHandler
+    {
+        private readonly RequestDelegate _next;
+        private readonly ILogger<DynamicExceptionHandler> _logger;
+        private readonly IDynamicExceptionMap _map;
+
+        public DynamicExceptionHandler(RequestDelegate next, IDynamicExceptionMap map, ILogger<DynamicExceptionHandler> logger)
+        {
+            _next = next;
+            _logger = logger;
+            _map = map;
+        }
+
+
+
+        /// <summary>
+        /// Handle an exception.
+        /// </summary>
+        /// <param name="context"></param>
+        /// <returns></returns>
+        public async Task Invoke(HttpContext context)
+        {
+            try
+            {
+                await _next(context);
+            }
+            catch (Exception error)
+            {
+                // generate a unique id to allow correlation between the output message (if any) and the log information
+                var exceptionUid = Guid.NewGuid();
+                // regardless of what happened, log the exception, and add the path and the Uid as attributes.
+                var logger = _logger.Technical().Exception(error)
+                    .Add(DefaultExceptionHandler.ExceptionUidKey, exceptionUid.ToString());
+
+                // optionally add the controller method if it is available
+                var methodInfo = context.GetEndpoint()?.Metadata.GetMetadata<ControllerActionDescriptor>()?.MethodInfo;
+                if (methodInfo is not null)
+                    logger.Add(nameof(methodInfo.DeclaringType), methodInfo.DeclaringType.Name)
+                        .Add(nameof(methodInfo.Name), methodInfo.Name);
+                // log everthing now
+                logger.Log();
+
+                if (_map.TryGetValue(error.GetType(), out var item))
+                {
+                    // a handler was found. Trigger it
+                    var task = (Task<(int StatusCode, object Value)>)item.Handler.DynamicInvoke(context.Request.Path.ToString(), error, exceptionUid);
+                    var result = await task;
+                    context.Response.StatusCode = result.StatusCode;
+                    if (result.Value is not null)
+                        await context.Response.WriteAsJsonAsync(result.Value);
+                }
+                else
+                {
+                    // if none of the handlers were triggered, use our default reply
+                    var messages = new Messages { new Message(ServiceModel.MessageCategory.Technical, MessageType.Error, $"A technical error occured. {DefaultExceptionHandler.ExceptionUidKey} = {exceptionUid}") };
+                    context.Response.StatusCode = StatusCodes.Status400BadRequest;
+                    await context.Response.WriteAsJsonAsync(messages);
+                }
+            }
+        }
+    }
+}
+

--- a/src/Arc4u.Standard.Diagnostics.AspNetCore/DynamicExceptionHandlerExtensions.cs
+++ b/src/Arc4u.Standard.Diagnostics.AspNetCore/DynamicExceptionHandlerExtensions.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+
+namespace Arc4u.Standard.Diagnostics.AspNetCore
+{
+    public static class DynamicExceptionHandlerExtensions
+    {
+        /// <summary>
+        /// Add the dynamic exception handler
+        /// </summary>
+        /// <param name="services"></param>
+        /// <returns></returns>
+        public static IServiceCollection AddDynamicExceptionHandler(this IServiceCollection services)
+        {
+            var exceptionMap = new DynamicExceptionMap();
+            services.AddSingleton<IDynamicExceptionHandlerBuilder>(exceptionMap);
+            services.AddSingleton<IDynamicExceptionMap>(exceptionMap);
+            return services.AddSingleton<DynamicExceptionMap>();
+        }
+
+        /// <summary>
+        /// Add and configure the dynamic exception handler
+        /// </summary>
+        /// <param name="app"></param>
+        /// <param name="config">a configurator for the exception handler to specify what to do with exceptions</param>
+        /// <returns></returns>
+        public static IApplicationBuilder UseDynamicExceptionHandler(this IApplicationBuilder app, Action<IDynamicExceptionHandlerBuilder> config)
+        {
+            var builder = app.ApplicationServices.GetService<IDynamicExceptionHandlerBuilder>();
+            if (builder == null)
+                throw new ArgumentException($"You forgot to call {nameof(AddDynamicExceptionHandler)}", nameof(app));
+            config(builder);
+            app.UseMiddleware<DynamicExceptionHandler>();
+            return app;
+        }
+
+
+        /// <summary>
+        /// Add and configure the dynamic exception handler
+        /// </summary>
+        /// <param name="app"></param>
+        /// <returns></returns>
+        public static IApplicationBuilder UseDynamicExceptionHandler(this IApplicationBuilder app) => app.UseDynamicExceptionHandler(builder => { });
+    }
+}

--- a/src/Arc4u.Standard.Diagnostics.AspNetCore/DynamicExceptionHandlerExtensions.cs
+++ b/src/Arc4u.Standard.Diagnostics.AspNetCore/DynamicExceptionHandlerExtensions.cs
@@ -29,7 +29,7 @@ namespace Arc4u.Standard.Diagnostics.AspNetCore
         {
             var builder = app.ApplicationServices.GetService<IDynamicExceptionHandlerBuilder>();
             if (builder == null)
-                throw new ArgumentException($"You forgot to call {nameof(AddDynamicExceptionHandler)}", nameof(app));
+                throw new ArgumentException($"You forgot to call services.{nameof(AddDynamicExceptionHandler)}()", nameof(app));
             config(builder);
             app.UseMiddleware<DynamicExceptionHandler>();
             return app;

--- a/src/Arc4u.Standard.Diagnostics.AspNetCore/DynamicExceptionMap.cs
+++ b/src/Arc4u.Standard.Diagnostics.AspNetCore/DynamicExceptionMap.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Arc4u.Standard.Diagnostics.AspNetCore
+{
+    /// <summary>
+    /// This is a singleton instance holding the mapping between an exception and how to handle it.
+    /// It is used when building the configuration at startup, and consulted in the <see cref="DynamicExceptionHandler"/> at exception time.
+    /// </summary>
+    class DynamicExceptionMap : IDynamicExceptionHandlerBuilder, IDynamicExceptionMap
+    {
+        private readonly List<(Type ExceptionType, Delegate Handler)> _map;
+
+        public DynamicExceptionMap()
+        {
+            _map = new List<(Type ExceptionType, Delegate Handler)>();
+            // default behavior is to handle AppException and block everything else
+            Handle<AppException>(DefaultExceptionHandler.AppExceptionHandlerAsync);
+        }
+
+        public bool TryGetValue(Type exceptionType, out (Type ExceptionType, Delegate Handler) value)
+        {
+            foreach (var item in _map)
+                if (item.ExceptionType.IsAssignableFrom(exceptionType))
+                {
+                    value = item;
+                    return true;
+                }
+            value = default;
+            return false;
+        }
+
+
+        public IDynamicExceptionHandlerBuilder Handle<TException>(IDynamicExceptionHandlerBuilder.ExceptionHandlerDelegateAsync<TException> handler) where TException : Exception
+        {
+            if (handler is null)
+                throw new ArgumentNullException(nameof(handler));
+            // make sure we don't add the same type twice, or a more specific type after a more general type, since this will never be caught
+            // it's not an error to add a more general type after a more specific type, since the order of processing is linear and any more specific type will be handled first
+            foreach (var item in _map)
+                if (item.ExceptionType == typeof(TException))
+                    throw new ArgumentException($"There is already a handler for {typeof(TException).Name}", nameof(TException));
+                else if (item.ExceptionType.IsAssignableFrom(typeof(TException)))
+                    throw new ArgumentException($"The handler for {typeof(TException).Name} will never be reached since there is already a handler for the base type {item.ExceptionType.Name}", nameof(TException));
+            _map.Add((typeof(TException), handler));
+            return this;
+        }
+    }
+}

--- a/src/Arc4u.Standard.Diagnostics.AspNetCore/ExceptionPropertyValues.cs
+++ b/src/Arc4u.Standard.Diagnostics.AspNetCore/ExceptionPropertyValues.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Arc4u.Standard.Diagnostics.AspNetCore
+{
+    static class ExceptionPropertyValues
+    {
+        /// <summary>
+        /// Get the property values of an object (which is really a <see cref="Exception"/> in our case) transformed in a way that serialization using Json will be able to handle.
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <returns></returns>
+        public static object GetSerializable(object obj)
+        {
+            return GetSerializable(obj, new HashSet<object>());
+        }
+
+        private static object GetSerializable(object obj, HashSet<object> visited)
+        {
+            if (obj is null)
+                return null;
+            var type = obj.GetType();
+            try
+            {
+                if (IsSimpleType(type))
+                    return obj;
+                // special case for Type and all derivates: just serialize their name
+                if (obj is Type t)
+                    return t.Name;
+                // avoid endless loops for reference types. This is unlikely to occur in exception instances, but one never knows.
+                if (visited.Add(obj))
+                {
+                    // dictionaries with strings are special in Json, they have a compact serialization format
+                    if (type.GetInterfaces().Any(x => x.IsGenericType && (x.GetGenericTypeDefinition() == typeof(IDictionary<,>) || x.GetGenericTypeDefinition() == typeof(IReadOnlyDictionary<,>)) && x.GetGenericArguments()[0] == typeof(string)))
+                    {
+                        //return Format((dynamic)obj, visited);
+                        var dictionary = new Dictionary<string, object>();
+                        foreach (var item in (System.Collections.IEnumerable)obj)
+                        {
+                            var itemType = item.GetType();
+                            var key = itemType.GetProperty("Key").GetValue(item);
+                            var value = itemType.GetProperty("Value").GetValue(item);
+                            dictionary[key.ToString()] = GetSerializable(value, visited);
+                        }
+                        return dictionary;
+                    }
+                    else if (obj is System.Collections.IEnumerable enumerable)
+                    {
+                        // this will handle arrays and all collections
+                        var collection = new List<object>();
+                        foreach (var item in enumerable)
+                            collection.Add(GetSerializable(item, visited));
+                        return collection.ToArray();
+                    }
+                    else
+                    {
+                        Dictionary<string, object> properties = new Dictionary<string, object>();
+                        foreach (var property in type.GetProperties())
+                        {
+                            // we don't want to deserialize Exception.TargetSize, since it's huge and brings no benefit
+                            if (property.DeclaringType == typeof(Exception) && property.Name == nameof(Exception.TargetSite))
+                                continue;
+                            var value = property.GetValue(obj);
+                            properties[property.Name] = GetSerializable(value, visited);
+                        }
+                        return properties;
+                    }
+                }
+                else
+                    return "Instance already serialized";
+            }
+            catch
+            {
+                return $"Unable to serialize {type.Name}";
+            }
+        }
+
+        /// <summary>
+        /// Format a dictionary with strings as keys into something that Json recognizes as a structure
+        /// </summary>
+        /// <typeparam name="TKey"></typeparam>
+        /// <typeparam name="TValue"></typeparam>
+        /// <param name="dictionary"></param>
+        /// <param name="visited"></param>
+        /// <returns></returns>
+        private static Dictionary<string, object> Format<TKey, TValue>(IEnumerable<KeyValuePair<string, TValue>> dictionary, HashSet<object> visited)
+        {
+            var elements = new Dictionary<string, object>();
+            foreach (var item in dictionary)
+                elements[item.Key] = GetSerializable(item.Value, visited);
+            return elements;
+        }
+
+
+        /// <summary>
+        /// Return true if the <paramref name="type"/> is simple enough and requires no transformation to be serializable by default.
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        private static bool IsSimpleType(Type type)
+        {
+            // Nullables are simple if their underlying type is simple
+            if (type.IsValueType && type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>))
+                type = Nullable.GetUnderlyingType(type);
+            // enums and other simple things are OK
+            if (type.IsEnum || type == typeof(Guid) || type == typeof(DateTimeOffset))
+                return true;
+            var typeCode = Type.GetTypeCode(type);
+            if (typeCode == TypeCode.Empty || typeCode == TypeCode.Object)
+                return false;
+            // all the other type codes are things that Json can serialize by default.
+            return true;
+        }
+    }
+}

--- a/src/Arc4u.Standard.Diagnostics.AspNetCore/IDynamicExceptionHandlerBuilder.cs
+++ b/src/Arc4u.Standard.Diagnostics.AspNetCore/IDynamicExceptionHandlerBuilder.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Arc4u.Standard.Diagnostics.AspNetCore
+{
+    public interface IDynamicExceptionHandlerBuilder
+    {
+        /// <summary>
+        /// A handler delegate that maps an exception to a status code and something to stream back in the response.
+        /// </summary>
+        /// <param name="path">The path of the handler that triggered the exception</param>
+        /// <param name="error">The actual exception</param>
+        /// <param name="uid">A unique identifier identifying the exception. Used as a correlation between the respone and the log</param>
+        /// <returns>A tuple with the status code and the value to be written in the response body as Json. If the value is null, nothing is written to the response body</returns>
+        /// <remarks>It is not clear if making this an async method is really an asset.</remarks>
+        delegate Task<(int StatusCode, object Value)> ExceptionHandlerDelegateAsync<TException>(string path, TException error, Guid uid) where TException : Exception;
+
+        /// <summary>
+        /// Handle an exception by executing its handler.
+        /// If more than one call is made to this method, the order is important since exceptions whose type derives from <paramref name="exceptionType"/> will also be matched, not only those of exact type.
+        /// </summary>
+        /// <typeparam name="TException">The type of the exception that will trigger the handler. Derived exception will also trigger the handler, unless their handler has been defined first</typeparam>
+        /// <param name="handler">The handler to execute</param>
+        /// <returns></returns>
+        IDynamicExceptionHandlerBuilder Handle<TException>(ExceptionHandlerDelegateAsync<TException> handler) where TException : Exception;
+    }
+}

--- a/src/Arc4u.Standard.Diagnostics.AspNetCore/IDynamicExceptionHandlerBuilder.cs
+++ b/src/Arc4u.Standard.Diagnostics.AspNetCore/IDynamicExceptionHandlerBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Arc4u.Standard.Diagnostics.AspNetCore
@@ -11,9 +12,27 @@ namespace Arc4u.Standard.Diagnostics.AspNetCore
         /// <param name="path">The path of the handler that triggered the exception</param>
         /// <param name="error">The actual exception</param>
         /// <param name="uid">A unique identifier identifying the exception. Used as a correlation between the respone and the log</param>
+        /// <param name="cancellationToken"></param>
         /// <returns>A tuple with the status code and the value to be written in the response body as Json. If the value is null, nothing is written to the response body</returns>
-        /// <remarks>It is not clear if making this an async method is really an asset.</remarks>
-        delegate Task<(int StatusCode, object Value)> ExceptionHandlerDelegateAsync<TException>(string path, TException error, Guid uid) where TException : Exception;
+        delegate Task<(int StatusCode, object Value)> ExceptionHandlerAsyncDelegate<TException>(string path, TException error, Guid uid, CancellationToken cancellationToken) where TException : Exception;
+
+        /// <summary>
+        /// A handler delegate that maps an exception to a status code and something to stream back in the response.
+        /// </summary>
+        /// <param name="path">The path of the handler that triggered the exception</param>
+        /// <param name="error">The actual exception</param>
+        /// <param name="uid">A unique identifier identifying the exception. Used as a correlation between the respone and the log</param>
+        /// <returns>A tuple with the status code and the value to be written in the response body as Json. If the value is null, nothing is written to the response body</returns>
+        delegate (int StatusCode, object Value) ExceptionHandlerDelegate<TException>(string path, TException error, Guid uid) where TException : Exception;
+
+        /// <summary>
+        /// Handle an exception by executing its handler.
+        /// If more than one call is made to this method, the order is important since exceptions whose type derives from <paramref name="exceptionType"/> will also be matched, not only those of exact type.
+        /// </summary>
+        /// <typeparam name="TException">The type of the exception that will trigger the handler. Derived exception will also trigger the handler, unless their handler has been defined first</typeparam>
+        /// <param name="handlerAsync">The handler to execute</param>
+        /// <returns></returns>
+        IDynamicExceptionHandlerBuilder Handle<TException>(ExceptionHandlerAsyncDelegate<TException> handlerAsync) where TException : Exception;
 
         /// <summary>
         /// Handle an exception by executing its handler.
@@ -22,6 +41,6 @@ namespace Arc4u.Standard.Diagnostics.AspNetCore
         /// <typeparam name="TException">The type of the exception that will trigger the handler. Derived exception will also trigger the handler, unless their handler has been defined first</typeparam>
         /// <param name="handler">The handler to execute</param>
         /// <returns></returns>
-        IDynamicExceptionHandlerBuilder Handle<TException>(ExceptionHandlerDelegateAsync<TException> handler) where TException : Exception;
+        IDynamicExceptionHandlerBuilder Handle<TException>(ExceptionHandlerDelegate<TException> handler) where TException : Exception;
     }
 }

--- a/src/Arc4u.Standard.Diagnostics.AspNetCore/IDynamicExceptionMap.cs
+++ b/src/Arc4u.Standard.Diagnostics.AspNetCore/IDynamicExceptionMap.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Arc4u.Standard.Diagnostics.AspNetCore
+{
+    public interface IDynamicExceptionMap
+    {
+        bool TryGetValue(Type exceptionType, out (Type ExceptionType, Delegate Handler) value);
+    }
+}

--- a/src/Arc4u.Standard.Diagnostics.AspNetCore/IDynamicExceptionMap.cs
+++ b/src/Arc4u.Standard.Diagnostics.AspNetCore/IDynamicExceptionMap.cs
@@ -2,8 +2,8 @@
 
 namespace Arc4u.Standard.Diagnostics.AspNetCore
 {
-    public interface IDynamicExceptionMap
+    interface IDynamicExceptionMap
     {
-        bool TryGetValue(Type exceptionType, out (Type ExceptionType, Delegate Handler) value);
+        bool TryGetValue(Type exceptionType, out (Type ExceptionType, Delegate Handler, Delegate HandlerAsync) value);
     }
 }

--- a/src/Arc4u.Standard.OAuth2.AspNetCore.Api/Aspect/ServiceAspectBase.cs
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore.Api/Aspect/ServiceAspectBase.cs
@@ -1,8 +1,5 @@
-﻿using Arc4u.Diagnostics;
-using Arc4u.ServiceModel;
-using Microsoft.AspNetCore.Http;
+﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Extensions.Logging;
 using System;
@@ -19,7 +16,7 @@ namespace Arc4u.OAuth2.Aspect
     /// Handle AppException or Exception and return a Bad RequestMessage.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, Inherited = true, AllowMultiple = false)]
-    public abstract class ServiceAspectBase : ActionFilterAttribute, IAsyncAuthorizationFilter, IExceptionFilter
+    public abstract class ServiceAspectBase : ActionFilterAttribute, IAsyncAuthorizationFilter
     {
         /// <summary>
         /// The page used to render when you are unauthorized.
@@ -67,30 +64,6 @@ namespace Arc4u.OAuth2.Aspect
             context.Result = new UnauthorizedResult();
 
             return Task.CompletedTask;
-        }
-
-        public void OnException(ExceptionContext context)
-        {
-            if (context.ActionDescriptor is ControllerActionDescriptor descriptor)
-                Logger.Technical().From(descriptor.MethodInfo.DeclaringType, descriptor.MethodInfo.Name).Exception(context.Exception).Log();
-            else
-                Logger.Technical().From(typeof(ServiceAspectBase)).Exception(context.Exception).Log();
-
-            Messages messages;
-            if (context.Exception is AppException appException)
-            {
-                messages = Messages.FromEnum(appException.Messages);
-                messages.LocalizeAll();
-            }
-            else
-            {
-                messages = new Messages
-                {
-                    new Message(Arc4u.ServiceModel.MessageCategory.Technical, Arc4u.ServiceModel.MessageType.Error, "A technical error occured.")
-                };
-            }
-
-            context.Result = new BadRequestObjectResult(messages);
         }
     }
 }

--- a/src/Arc4u.sln
+++ b/src/Arc4u.sln
@@ -97,6 +97,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Arc4u.Standard.OAuth2.AspNe
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Arc4u.Standard.OData", "Arc4u.Standard.OData\Arc4u.Standard.OData.csproj", "{6ED0D79F-96D4-418A-9C75-69E165FA5682}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Arc4u.Standard.Diagnostics.AspNetCore", "Arc4u.Standard.Diagnostics.AspNetCore\Arc4u.Standard.Diagnostics.AspNetCore.csproj", "{597FAAF9-92E5-4BBC-93BA-DE96E8496DD9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -951,6 +953,26 @@ Global
 		{6ED0D79F-96D4-418A-9C75-69E165FA5682}.Release|x64.Build.0 = Release|Any CPU
 		{6ED0D79F-96D4-418A-9C75-69E165FA5682}.Release|x86.ActiveCfg = Release|Any CPU
 		{6ED0D79F-96D4-418A-9C75-69E165FA5682}.Release|x86.Build.0 = Release|Any CPU
+		{597FAAF9-92E5-4BBC-93BA-DE96E8496DD9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{597FAAF9-92E5-4BBC-93BA-DE96E8496DD9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{597FAAF9-92E5-4BBC-93BA-DE96E8496DD9}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{597FAAF9-92E5-4BBC-93BA-DE96E8496DD9}.Debug|ARM.Build.0 = Debug|Any CPU
+		{597FAAF9-92E5-4BBC-93BA-DE96E8496DD9}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{597FAAF9-92E5-4BBC-93BA-DE96E8496DD9}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{597FAAF9-92E5-4BBC-93BA-DE96E8496DD9}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{597FAAF9-92E5-4BBC-93BA-DE96E8496DD9}.Debug|x64.Build.0 = Debug|Any CPU
+		{597FAAF9-92E5-4BBC-93BA-DE96E8496DD9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{597FAAF9-92E5-4BBC-93BA-DE96E8496DD9}.Debug|x86.Build.0 = Debug|Any CPU
+		{597FAAF9-92E5-4BBC-93BA-DE96E8496DD9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{597FAAF9-92E5-4BBC-93BA-DE96E8496DD9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{597FAAF9-92E5-4BBC-93BA-DE96E8496DD9}.Release|ARM.ActiveCfg = Release|Any CPU
+		{597FAAF9-92E5-4BBC-93BA-DE96E8496DD9}.Release|ARM.Build.0 = Release|Any CPU
+		{597FAAF9-92E5-4BBC-93BA-DE96E8496DD9}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{597FAAF9-92E5-4BBC-93BA-DE96E8496DD9}.Release|ARM64.Build.0 = Release|Any CPU
+		{597FAAF9-92E5-4BBC-93BA-DE96E8496DD9}.Release|x64.ActiveCfg = Release|Any CPU
+		{597FAAF9-92E5-4BBC-93BA-DE96E8496DD9}.Release|x64.Build.0 = Release|Any CPU
+		{597FAAF9-92E5-4BBC-93BA-DE96E8496DD9}.Release|x86.ActiveCfg = Release|Any CPU
+		{597FAAF9-92E5-4BBC-93BA-DE96E8496DD9}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This is a proposal for a new exception handling mechanism that remains compatible with the existing behavior while offering extra flexibility.

This pull request is more about the mechanism than about the implementation. It is not expected to be integrated as-is.

Today, exception handling happens in [`ServiceAspectBase`](https://github.com/GFlisch/Arc4u/blob/master/src/Arc4u.Standard.OAuth2.AspNetCore.Api/Aspect/ServiceAspectBase.cs) by implementing `IExceptionFilter` and mapping all exceptions to a fixed message ("_A technical error occurred_") except [`AppException`](https://github.com/GFlisch/Arc4u/blob/master/src/Arc4u.Standard/Exceptions/AppException.cs), which is written as a representation of its messages.

This pull request removes the exception handling from `ServiceAspectBase`. Exception handling is now performed in a separate middleware. This middleware and its helper classes are implemented in a new assembly called `Arc4u.Standard.Diagnostics.AspNetCore`.

To use this middleware, the classical `Add..`/`Use...` pattern is used. In the startup code of the web service you need to add:

~~~csharp
    services.AddDynamicExceptionHandler();
~~~

... during construction of the service collection.

After the host is built, you need to add `app.UseDynamicExceptionHandler();`. Since this is a middlware treating exceptions, it needs to be the very last middleware added. For example, here is the call shown after the call to `MapReverseProxy()`:

~~~csharp
    app.MapControllers();
    app.MapGrpcReflectionService();
    app.MapHealthChecksUI();
    app.MapReverseProxy();

    app.UseDynamicExceptionHandler();

~~~

When this is done, the back-end is ready to handle exceptions again. The only observable change is the inclusion of a `Guid` in the error message  The message becomes:

~~~
A technical error occurred. ExceptionUid = 90db5c7f-c3df-4879-9f2a-3491e4921372
~~~

The log entry will contain an attribute called `ExceptionUid` and the details can be looked up using the given attribute value.

All exceptions other than `AppException` will show this message. `AppException` content will be shown as before.

But sometimes, you would like to handle specific exception types in a customized way. Perhaps these exceptions originate from another library outside of your control, and you still want to give the client more information.

The `UseDynamicExceptionHelper` has another overload for this purpose:

~~~csharp
public static IApplicationBuilder UseDynamicExceptionHandler(this IApplicationBuilder app, Action<IDynamicExceptionHandlerBuilder> config)
~~~

The `IDynamicExceptionHandlerBuilder` can be used to configure what needs to happen for certain exception types. The interface is defined as follows:

~~~csharp
    public interface IDynamicExceptionHandlerBuilder
    {
        /// <summary>
        /// A handler delegate that maps an exception to a status code and something to stream back in the response.
        /// </summary>
        /// <param name="path">The path of the handler that triggered the exception</param>
        /// <param name="error">The actual exception</param>
        /// <param name="uid">A unique identifier identifying the exception. Used as a correlation between the respone and the log</param>
        /// <param name="cancellationToken"></param>
        /// <returns>A tuple with the status code and the value to be written in the response body as Json. If the value is null, nothing is written to the response body</returns>
        delegate Task<(int StatusCode, object Value)> ExceptionHandlerAsyncDelegate<TException>(string path, TException error, Guid uid, CancellationToken cancellationToken) where TException : Exception;

        /// <summary>
        /// A handler delegate that maps an exception to a status code and something to stream back in the response.
        /// </summary>
        /// <param name="path">The path of the handler that triggered the exception</param>
        /// <param name="error">The actual exception</param>
        /// <param name="uid">A unique identifier identifying the exception. Used as a correlation between the respone and the log</param>
        /// <returns>A tuple with the status code and the value to be written in the response body as Json. If the value is null, nothing is written to the response body</returns>
        delegate (int StatusCode, object Value) ExceptionHandlerDelegate<TException>(string path, TException error, Guid uid) where TException : Exception;

        /// <summary>
        /// Handle an exception by executing its handler.
        /// If more than one call is made to this method, the order is important since exceptions whose type derives from <paramref name="exceptionType"/> will also be matched, not only those of exact type.
        /// </summary>
        /// <typeparam name="TException">The type of the exception that will trigger the handler. Derived exception will also trigger the handler, unless their handler has been defined first</typeparam>
        /// <param name="handlerAsync">The handler to execute</param>
        /// <returns></returns>
        IDynamicExceptionHandlerBuilder Handle<TException>(ExceptionHandlerAsyncDelegate<TException> handlerAsync) where TException : Exception;

        /// <summary>
        /// Handle an exception by executing its handler.
        /// If more than one call is made to this method, the order is important since exceptions whose type derives from <paramref name="exceptionType"/> will also be matched, not only those of exact type.
        /// </summary>
        /// <typeparam name="TException">The type of the exception that will trigger the handler. Derived exception will also trigger the handler, unless their handler has been defined first</typeparam>
        /// <param name="handler">The handler to execute</param>
        /// <returns></returns>
        IDynamicExceptionHandlerBuilder Handle<TException>(ExceptionHandlerDelegate<TException> handler) where TException : Exception;
    }
~~~

This interface allows you to associate an exception type with a handler.  A handler can be synchronous or asynchronous, as determined by its signature in the `IDynamicExceptionHandlerBuilder` interface.:  ' ExceptionHandlerDelegate' for synchronous or `ExceptionHandlerAsyncDelegate` for asynchronous.

The first 3 parameters of a handler are:
- `path`, which is the path to the endpoint that triggered the exception
- `error`, which is the exception being thrown
- `uid`, which is the unique identifier associated with this exception. This is what will also be written in the log.

There is a 4th parameter in the asynchronous case, a cancellation token as per convention.

The handler returns a tuple of two items, consisting of:
- `StatusCode`, the status code to return
- `Value`, the object to write to the response body. If this is null, nothing will be written to the response body.

This allows great flexibility by returning as many (or as few) details for any exception you want.  This is a fluent API, so calls to `Handle` can be chained. The chaining order is important: if you want to handle an exception hierarchy, add the more specific exceptions first, and the base exceptions later.

For example, suppose you have a business exception defined as follows:

~~~csharp
public sealed class BusinessException : Exception
{
    public int ExtraStuff { get; }

    public int[] ExtraInt { get; } = { 1, 2, 3 };

    public Dictionary<string, string> ExtraDict1 { get; } = new Dictionary<string, string> { { "A", "1" }, { "B", "2" } };

    public Dictionary<int, int> ExtraDict2 { get; } = new Dictionary<int, int> { { 1, 2 }, { 3, 4 } };


    public BusinessException(int extraStuff, string message, Exception innerException)
        : base(message, innerException)
    {
    }
}
~~~

A silly definition, but it's for illustrative purposes.

Without extra configuration, throwing this exception would generate "A technical error has occurred". If you want to return (for example) the exception message and the uid, you can write the following:

~~~csharp
    app.UseDynamicExceptionHandler(
        config => config.Handle<BusinessException>(
                (path, error, uid) => (StatusCodes.Status500InternalServerError, (object)$"{error.Message} {uid}")
                ));
~~~

An exception thrown like this:

~~~csharp
        throw new BusinessException(42, "hello world", null);
~~~

... will get you this response (with status 500):

~~~
"hello world a9a250fd-54c9-4b37-ac9d-4b0663f0a43b"
~~~

You can write your own handler, or you can use the two definitions already provided in the 'DefaultExceptionHandler' class:

~~~csharp
        public static Task<(int StatusCode, object Value)> DefaultExceptionHandler.GenericExceptionHandler<TException>(string path, TException exception, Guid uid) where TException : Exception

        public static Task<(int StatusCode, object Value)> DefaultExceptionHandler.GenericExceptionHandlerWithDetails<TException>(string path, TException exception, Guid uid) where TException : Exception

~~~

The `GenericExceptionHandler` will return exception information wrapped in a [RFC 7807](https://tools.ietf.org/html/rfc7807)-compliant `ProblemDetails` structure. 
The configuration looks like this:

~~~csharp
    app.UseDynamicExceptionHandler(
      config =>
            {
                config.Handle<BusinessException>(DefaultExceptionHandler.GenericExceptionHandler<BusinessException>);
            });
~~~

The response in this case would be a status 400 (bad request) with the following body:

~~~json
{
  "title": "hello world",
  "status": 400,
  "instance": "/facade/Environment",
  "ExceptionUid": "e847a395-c58c-4a3a-a9ee-4e030758bed5"
}
~~~

The `GenericExceptionHandlerWithDetails` does the same thing but includes all exception properties.
The configuragion looks like this:

~~~csharp
    app.UseDynamicExceptionHandler(
      config =>
            {
                config.Handle<BusinessException>(DefaultExceptionHandler.GenericExceptionHandlerWithDetails<BusinessException>);
            });
~~~

The response in this case would be a status 400 (bad request) with all the properties of the exception.

~~~json
{
  "title": "hello world",
  "status": 400,
  "instance": "/facade/Environment",
  "ExceptionUid": "e9e7aa7f-bd54-46ab-88ba-ab54ffc13ee7",
  "ExceptionInstance": {
    "ExtraStuff": 0,
    "ExtraInt": [
      1,
      2,
      3
    ],
    "ExtraDict1": {
      "A": "1",
      "B": "2"
    },
    "ExtraDict2": [
      {
        "Key": 1,
        "Value": 2
      },
      {
        "Key": 3,
        "Value": 4
      }
    ],
    "Message": "hello world",
    "Data": [],
    "InnerException": null,
    "HelpLink": null,
    "Source": "HappyFlow.Yarp.Facade",
    "HResult": -2146233088,
    "StackTrace": "   at Elia.HappyFlow.Yarp.Facade.EnvironmentController.GetAsync() in C:\\PRJ\\HappyFlow\\HappyFlow\\BE\\Yarp\\HappyFlow.Yarp.Facade\\EnvironmentController.cs:line 65\r\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.TaskOfIActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)\r\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Awaited|12_0(ControllerActionInvoker invoker, ValueTask`1 actionResultValueTask)\r\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)\r\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)\r\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)\r\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeFilterPipelineAsync>g__Awaited|20_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)\r\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Awaited|17_0(ResourceInvoker invoker, Task task, IDisposable scope)\r\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Awaited|17_0(ResourceInvoker invoker, Task task, IDisposable scope)\r\n   at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)\r\n   at Arc4u.Standard.Diagnostics.AspNetCore.DynamicExceptionHandler.Invoke(HttpContext context) in C:\\PRJ\\Arc4uGit\\src\\Arc4u.Standard.Diagnostics.AspNetCore\\DynamicExceptionHandler.cs:line 39"
  }
}

~~~

When we'move move beyond .NET 6.0, we will be able to integrate the built-in `ProblemDetails` handling in .NET 7.