### PR TITLE
Better logging of AggregateException instances

### DIFF
--- a/src/Arc4u.Standard.Diagnostics/Fluent/Common/CommonLoggerProperties.cs
+++ b/src/Arc4u.Standard.Diagnostics/Fluent/Common/CommonLoggerProperties.cs
@@ -85,7 +85,7 @@ namespace Arc4u.Diagnostics
         /// </summary>
         /// <param name="stackTrace"></param>
         /// <returns>the cleaned-up stack trace</returns>
-        private static string CleanupStackTrace(string stackTrace)
+        internal static string CleanupStackTrace(string stackTrace)
         {
             var traces = new StringReader(stackTrace);
             var output = new StringBuilder();

--- a/src/Arc4u.Standard.Diagnostics/Fluent/Common/CommonMessageLogger.cs
+++ b/src/Arc4u.Standard.Diagnostics/Fluent/Common/CommonMessageLogger.cs
@@ -86,9 +86,7 @@ namespace Arc4u.Diagnostics
 
         public void LogException(Exception exception)
         {
-            var property = AddEntry(LogLevel.Error, exception.Message, exception);
-            var buildMessage = property.AddStacktrace(exception.StackTrace ?? Environment.StackTrace);
-            buildMessage.Log();
+            Exception(exception).Log();
         }
 
         internal CommonLoggerProperties System(string message, params object[] args)

--- a/src/Arc4u.Standard.Diagnostics/LoggerMessage.cs
+++ b/src/Arc4u.Standard.Diagnostics/LoggerMessage.cs
@@ -70,6 +70,20 @@ namespace Arc4u.Diagnostics
             // Add the internal Arc4u properties to whatever the TState provides already before logging
             var stateLogger = new StateLogger(Properties, _logger);
             stateLogger.Log(LogLevel, 0, Exception, Text, Args);
+
+            // if this was an aggregate exception (a common occurrence in async programming), we also log the individual innner exceptions, which is better than just "One or more errors occurred".
+            if (Exception is AggregateException aggregateException)
+                foreach (var innerException in aggregateException.InnerExceptions)
+                {
+                    // we know that if we have an exception, the Text property is the message of the exception so we call the state logger with the message of the inner exception instead.
+                    // we also replace the stack trace with the exception's stack trace. Strictly speaking, this changes the state of the LoggerMessage but since Log() is supposed to
+                    // be the last method called, we don't mind.
+                    if (string.IsNullOrEmpty(innerException.StackTrace))
+                        Properties.Remove(LoggingConstants.Stacktrace);
+                    else
+                        Properties[LoggingConstants.Stacktrace] = CommonLoggerProperties.CleanupStackTrace(innerException.StackTrace);
+                    stateLogger.Log(LogLevel, 0, innerException, innerException.Message, Args);
+                }
         }
     }
 


### PR DESCRIPTION
Instances of `AggregateException` are commonly thrown in the context of async code.
The problem is that they are logged with only their default message, which is always the same:

> One or more errors occurred.

This pull request keeps logging the default message, but also logs the detailed inner exceptions with their separate messages and stack traces.