### PR TITLE
Change the resolver name from OAuth to OAuth2

### DIFF
--- a/src/Arc4u.Standard.OAuth2.AspNetCore.Blazor/BlazorController.cs
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore.Blazor/BlazorController.cs
@@ -78,7 +78,7 @@ namespace Arc4u.Blazor
 
             if (accessToken.Length > index * buffer)
             {
-                containerResolve.TryResolve<IKeyValueSettings>("OAuth", out var settings);
+                containerResolve.TryResolve<IKeyValueSettings>("OAuth2", out var settings);
                 var thisController = settings.Values[TokenKeys.RootServiceUrlKey].TrimEnd('/') + $"/blazor/redirectto/{redirectTo}/{index + 1}&token={accessToken.Substring((index - 1) * buffer, buffer)}";
                 return Redirect(UriHelper.Encode(new Uri($"{redirectUri}?url={thisController}")));
             }


### PR DESCRIPTION
This modification is specific to .NET 6. The new guidance utilizes the `OAuth2` naming for settings, making it appropriate to update the `BlazorController` to comply with these guidelines. This will eliminate the need to rename the appsettings sections and reader classes. Additionally, this controller is currently only utilized by ADAL, but it will be replaced by MSAL in the future, so new projects will not require this controller.