### PR TITLE
Add missing GetDefaultMessageTemplates

### DIFF
--- a/src/Arc4u.Standard.FluentValidation/Rules/IsUtcDateOnlyRuleValidator.cs
+++ b/src/Arc4u.Standard.FluentValidation/Rules/IsUtcDateOnlyRuleValidator.cs
@@ -1,4 +1,4 @@
-﻿using FluentValidation;
+using FluentValidation;
 using FluentValidation.Resources;
 using FluentValidation.Validators;
 using System;
@@ -8,23 +8,24 @@ namespace Arc4u.FluentValidation.Rules
 
     internal class IsUtcDateOnlyRuleValidator<T, TProperty> : PropertyValidator<T, TProperty> where T : class where TProperty : struct
     {
-
         static string ruleName = "IsUtcDateOnlyRuleValidator";
+        public override string Name => ruleName;
+
         static IsUtcDateOnlyRuleValidator()
         {
             var lgMgr = ValidatorOptions.Global.LanguageManager as LanguageManager;
             lgMgr?.AddTranslation("en", ruleName, "Property must be a DateTime with no Time {PropertyValue}.");
         }
 
-        public override string Name => ruleName;
-
         public override bool IsValid(ValidationContext<T> context, TProperty value)
         {
             var dt = value as DateTime?;
-
             return dt.HasValue && dt.Value.TimeOfDay.Equals(TimeSpan.Zero);
+        }
 
-
+        protected override string GetDefaultMessageTemplate(string errorCode)
+        {
+            return Localized(errorCode, Name);
         }
     }
 }

--- a/src/Arc4u.Standard.FluentValidation/Rules/IsUtcDateTimeRuleValidator.cs
+++ b/src/Arc4u.Standard.FluentValidation/Rules/IsUtcDateTimeRuleValidator.cs
@@ -1,4 +1,4 @@
-﻿using FluentValidation;
+using FluentValidation;
 using FluentValidation.Resources;
 using FluentValidation.Validators;
 using System;
@@ -7,23 +7,24 @@ namespace Arc4u.FluentValidation.Rules
 {
     internal class IsUtcDateTimeRuleValidator<T, TProperty> : PropertyValidator<T, TProperty> where T : class where TProperty : struct
     {
-
         static string ruleName = "IsUtcDateTimeRuleValidator";
+        public override string Name => ruleName;
+
         static IsUtcDateTimeRuleValidator()
         {
             var lgMgr = ValidatorOptions.Global.LanguageManager as LanguageManager;
             lgMgr?.AddTranslation("en", ruleName, "Property must be a DateTime and in Utc {PropertyValue}.");
         }
 
-        public override string Name => ruleName;
-
         public override bool IsValid(ValidationContext<T> context, TProperty value)
         {
             var dt = value as DateTime?;
+            return dt is { Kind: DateTimeKind.Utc };
+        }
 
-            return dt.HasValue && dt.Value.Kind == DateTimeKind.Utc;
-
-
+        protected override string GetDefaultMessageTemplate(string errorCode)
+        {
+            return Localized(errorCode, Name);
         }
     }
 }


### PR DESCRIPTION
In Arc4u.FluentValidation.Rules in the classes

- IsUtcDateOnlyRuleValidator
- IsUtcDateTimeRuleValidator

the override of GetDefaultMessageTemplate is missing. So the provided error text through the languageManager isn't used correctly.