### PR TITLE
Code review

### DIFF
--- a/src/Arc4u.Standard.Caching.Memory/MemoryCache.cs
+++ b/src/Arc4u.Standard.Caching.Memory/MemoryCache.cs
@@ -38,21 +38,14 @@ public class MemoryCache : BaseDistributeCache, ICache
     public override void Initialize(string store)
 #endif
     {
-
-#if NET6_0_OR_GREATER
 #if NET7_0_OR_GREATER
-        ArgumentNullException.ThrowIfNullOrEmpty(store, nameof(store));
+        ArgumentException.ThrowIfNullOrEmpty(store);
 #else
-        ArgumentNullException.ThrowIfNull(store, nameof(store));
-#endif
-#else
-        if (store is null)
+        if (string.IsNullOrEmpty(store))
         {
-            throw new ArgumentNullException(nameof(store));
+            throw new ArgumentException("The value cannot be an empty string.", nameof(store));
         }
 #endif
-
-
 
         lock (_lock)
         {

--- a/src/Arc4u.Standard.Caching.Reddis/RedisCache.cs
+++ b/src/Arc4u.Standard.Caching.Reddis/RedisCache.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
 using Arc4u.Configuration.Redis;
 using Arc4u.Dependency;
 using Arc4u.Dependency.Attribute;
@@ -6,8 +8,6 @@ using Arc4u.Serializer;
 using Microsoft.Extensions.Caching.StackExchangeRedis;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using System;
-using System.Diagnostics.CodeAnalysis;
 using StackExchangeRedis = Microsoft.Extensions.Caching.StackExchangeRedis.RedisCache;
 
 namespace Arc4u.Caching.Redis;
@@ -15,7 +15,7 @@ namespace Arc4u.Caching.Redis;
 [Export("Redis", typeof(ICache))]
 public class RedisCache : BaseDistributeCache, ICache
 {
-     private string? Name { get; set; }
+    private string? Name { get; set; }
 
     private readonly ILogger<RedisCache> _logger;
 
@@ -29,14 +29,16 @@ public class RedisCache : BaseDistributeCache, ICache
         _logger = logger;
         _options = options;
     }
-   
+
     public override void Initialize([DisallowNull] string store)
     {
-#if NET6_0
-        ArgumentNullException.ThrowIfNull(store, nameof(store));
-#endif
 #if NET7_0_OR_GREATER
-        ArgumentNullException.ThrowIfNullOrEmpty(store, nameof(store));
+        ArgumentException.ThrowIfNullOrEmpty(store);
+#else
+        if (string.IsNullOrEmpty(store))
+        {
+            throw new ArgumentException("The value cannot be an empty string.", nameof(store));
+        }
 #endif
 
         lock (_lock)

--- a/src/Arc4u.Standard.Caching.Sql/SqlCache.cs
+++ b/src/Arc4u.Standard.Caching.Sql/SqlCache.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
 using Arc4u.Configuration.Sql;
 using Arc4u.Dependency;
 using Arc4u.Dependency.Attribute;
@@ -6,8 +8,6 @@ using Arc4u.Serializer;
 using Microsoft.Extensions.Caching.SqlServer;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using System;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Arc4u.Caching.Sql;
 
@@ -33,11 +33,13 @@ public class SqlCache : BaseDistributeCache, ICache
 
     public override void Initialize([DisallowNull] string store)
     {
-#if NET6_0
-        ArgumentNullException.ThrowIfNull(store, nameof(store));
-#endif
 #if NET7_0_OR_GREATER
-        ArgumentNullException.ThrowIfNullOrEmpty(store, nameof(store));
+        ArgumentException.ThrowIfNullOrEmpty(store);
+#else
+        if (string.IsNullOrEmpty(store))
+        {
+            throw new ArgumentException("The value cannot be an empty string.", nameof(store));
+        }
 #endif
 
         lock (_lock)

--- a/src/Arc4u.Standard.Caching/CacheContextServicesExtension.cs
+++ b/src/Arc4u.Standard.Caching/CacheContextServicesExtension.cs
@@ -14,7 +14,7 @@ public static class CacheContextServicesExtension
     public static void AddCacheContext(this IServiceCollection services, IConfiguration configuration, string sectionName = "Caching")
     {
 #if NET6_0_OR_GREATER
-       ArgumentNullException.ThrowIfNull(configuration, nameof(configuration));
+        ArgumentNullException.ThrowIfNull(configuration);
 #endif
 #if NETSTANDARD2_0_OR_GREATER
         if (configuration is null)

--- a/src/Arc4u.Standard.Caching/Configuration/MemoryCacheExtension.cs
+++ b/src/Arc4u.Standard.Caching/Configuration/MemoryCacheExtension.cs
@@ -24,16 +24,12 @@ public static class MemoryCacheExtension
             o.SerializerName = rawCacheOption.SerializerName;
         });
 
-#if NET6_0_OR_GREATER
 #if NET7_0_OR_GREATER
-        ArgumentNullException.ThrowIfNullOrEmpty(name, nameof(name));
+        ArgumentException.ThrowIfNullOrEmpty(name);
 #else
-        ArgumentNullException.ThrowIfNull(name, nameof(name));
-#endif
-#else
-        if (name is null)
+        if (string.IsNullOrEmpty(name))
         {
-            throw new ArgumentNullException(nameof(name));
+            throw new ArgumentException("The value cannot be an empty string.", nameof(name));
         }
 #endif
 

--- a/src/Arc4u.Standard.Caching/Configuration/RedisCacheExtension.cs
+++ b/src/Arc4u.Standard.Caching/Configuration/RedisCacheExtension.cs
@@ -2,6 +2,9 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+#if !NET7_0_OR_GREATER
+using System.Runtime.CompilerServices;
+#endif
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -13,21 +16,30 @@ public static class RedisCacheExtension
         var validate = new RedisCacheOption();
         new Action<RedisCacheOption>(options).Invoke(validate);
 
-#if NET6_0
-        ArgumentNullException.ThrowIfNull(name, nameof(name));
-        ArgumentNullException.ThrowIfNull(validate.ConnectionString, nameof(validate.ConnectionString));
-        ArgumentNullException.ThrowIfNull(validate.InstanceName, nameof(validate.InstanceName));
-#endif
 #if NET7_0_OR_GREATER
-        ArgumentNullException.ThrowIfNullOrEmpty(name, nameof(name));
-        ArgumentNullException.ThrowIfNullOrEmpty(validate.ConnectionString, nameof(validate.ConnectionString));
-        ArgumentNullException.ThrowIfNullOrEmpty(validate.InstanceName, nameof(validate.InstanceName));
+        ArgumentException.ThrowIfNullOrEmpty(name, nameof(name));
+        ArgumentException.ThrowIfNullOrEmpty(validate.ConnectionString, nameof(validate.ConnectionString));
+        ArgumentException.ThrowIfNullOrEmpty(validate.InstanceName, nameof(validate.InstanceName));
+#else
+        ThrowIfNullOrEmpty(name, nameof(name));
+        ThrowIfNullOrEmpty(validate.ConnectionString, nameof(validate.ConnectionString));
+        ThrowIfNullOrEmpty(validate.InstanceName, nameof(validate.InstanceName));
 #endif
 
         services.Configure<RedisCacheOption>(name, options);
 
         return services;
     }
+
+#if !NET7_0_OR_GREATER
+    private static void ThrowIfNullOrEmpty(string? s, [CallerArgumentExpression("s")] string? conditionExpression = null)
+    {
+        if (string.IsNullOrEmpty(s))
+        {
+            throw new ArgumentException("The value cannot be an empty string.", conditionExpression);
+        }
+    }
+#endif
 
     public static IServiceCollection AddRedisCache(this IServiceCollection services, [DisallowNull] string name, [DisallowNull] IConfiguration configuration, [DisallowNull] string sectionName)
     {

--- a/src/Arc4u.Standard.Caching/Configuration/SqlCacheExtension.cs
+++ b/src/Arc4u.Standard.Caching/Configuration/SqlCacheExtension.cs
@@ -1,8 +1,8 @@
 #if NET6_0_OR_GREATER
+using System;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using System.Diagnostics.CodeAnalysis;
-using System;
 
 namespace Arc4u.Configuration.Sql;
 public static class SqlCacheExtension
@@ -12,11 +12,13 @@ public static class SqlCacheExtension
         var validate = new SqlCacheOption();
         new Action<SqlCacheOption>(options).Invoke(validate);
 
-#if NET6_0
-        ArgumentNullException.ThrowIfNull(name, nameof(name));
-#endif
 #if NET7_0_OR_GREATER
-        ArgumentNullException.ThrowIfNullOrEmpty(name, nameof(name));
+        ArgumentException.ThrowIfNullOrEmpty(name);
+#else
+        if (string.IsNullOrEmpty(name))
+        {
+            throw new ArgumentException("The value cannot be an empty string.", nameof(name));
+        }
 #endif
 
         services.Configure<SqlCacheOption>(name, options);

--- a/src/Arc4u.Standard.Configuration.Decryptor/SecretConfigurationCertificateProvider.cs
+++ b/src/Arc4u.Standard.Configuration.Decryptor/SecretConfigurationCertificateProvider.cs
@@ -19,7 +19,7 @@ public class SecretConfigurationCertificateProvider : ConfigurationProvider
     /// <param name="configurationRoot">The <see cref="IConfigurationRoot"/>.</param>
     public SecretConfigurationCertificateProvider([DisallowNull] SecretCertificateOptions options, IConfigurationRoot configurationRoot)
     {
-        ArgumentNullException.ThrowIfNull(options, nameof(options));
+        ArgumentNullException.ThrowIfNull(options);
 
         _options = options;
         _configurationRoot = configurationRoot;

--- a/src/Arc4u.Standard.Configuration.Decryptor/SecretRijndaelConfigurationSource.cs
+++ b/src/Arc4u.Standard.Configuration.Decryptor/SecretRijndaelConfigurationSource.cs
@@ -1,4 +1,3 @@
-using Arc4u.Security;
 using Microsoft.Extensions.Configuration;
 
 namespace Arc4u.Configuration.Decryptor;
@@ -20,9 +19,9 @@ public class SecretRijndaelConfigurationSource : IConfigurationSource
     /// </summary>
     public SecretRijndaelConfigurationSource(SecretRijndaelOptions options)
     {
-        ArgumentNullException.ThrowIfNull(options, nameof(options));
+        ArgumentNullException.ThrowIfNull(options);
 
-         _options = new SecretRijndaelOptions
+        _options = new SecretRijndaelOptions
         {
             Prefix = options.Prefix ?? PrefixDefault,
             SecretSectionName = options.SecretSectionName ?? SecretSectionNameDefault,

--- a/src/Arc4u.Standard.Configuration/Configuration/Config.cs
+++ b/src/Arc4u.Standard.Configuration/Configuration/Config.cs
@@ -1,13 +1,9 @@
-using Microsoft.Extensions.Configuration;
-
 namespace Arc4u.Configuration;
 
 public class ApplicationConfig
 {
-    public ApplicationConfig() => Environment = new Environment();
-
-     /// <summary>
-    /// Name used to dentify the application when used externally other than logging!
+    /// <summary>
+    /// Name used to identify the application when used externally other than logging!
     /// Cache or authorization, etc...
     /// </summary>
     public string ApplicationName { get; set; }

--- a/src/Arc4u.Standard.Configuration/Configuration/ConfigurationHelper.cs
+++ b/src/Arc4u.Standard.Configuration/Configuration/ConfigurationHelper.cs
@@ -1,10 +1,9 @@
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
-using System.Runtime.CompilerServices;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Arc4u.Configuration;
 
@@ -76,24 +75,33 @@ public static class ConfigurationHelper
         var validate = new ApplicationConfig();
         option(validate);
 
+        // try to detect as many configuration errors as possible instead of stopping at the first misconfigured property.
+        // since the happy flow is the norm, it's OK to use just a string to concatenate messages instead of a full-blown list or StringBuilder.
+
+        string? configErrors = null;
         if (string.IsNullOrEmpty(validate.ApplicationName))
         {
-            throw new MissingFieldException("Application name is not defined in the intialization of the application config settings");
+            configErrors += "Application name is not defined in the intialization of the application config settings" + System.Environment.NewLine;
         }
 
         if (string.IsNullOrEmpty(validate.Environment.Name))
         {
-            throw new MissingFieldException("Application environment name is not defined in the intialization of the application config settings");
+            configErrors += "Application environment name is not defined in the intialization of the application config settings" + System.Environment.NewLine;
         }
 
         if (string.IsNullOrEmpty(validate.Environment.LoggingName))
         {
-            throw new MissingFieldException("Application environment logging name is not defined in the intialization of the application config settings");
+            configErrors += "Application environment logging name is not defined in the intialization of the application config settings" + System.Environment.NewLine;
         }
 
         if (string.IsNullOrEmpty(validate.Environment.TimeZone))
         {
-            throw new MissingFieldException("Application environment time zone is not defined in the intialization of the application config settings");
+            configErrors += "Application environment time zone is not defined in the intialization of the application config settings" + System.Environment.NewLine;
+        }
+
+        if (configErrors is not null)
+        {
+            throw new ConfigurationException(configErrors);
         }
 
         services.Configure<ApplicationConfig>(option);
@@ -103,7 +111,7 @@ public static class ConfigurationHelper
     {
         if (string.IsNullOrEmpty(sectionName))
         {
-            throw new ArgumentNullException(nameof (sectionName));
+            throw new ArgumentNullException(nameof(sectionName));
         }
 
         if (configuration is null)

--- a/src/Arc4u.Standard.OAuth2.AspNetCore.Authentication/DataProtection/CacheStore.cs
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore.Authentication/DataProtection/CacheStore.cs
@@ -2,13 +2,13 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Text.Json;
+using System.Xml.Linq;
+using Arc4u.Caching;
+using Arc4u.Diagnostics;
 using Microsoft.AspNetCore.DataProtection.Repositories;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using System.Xml.Linq;
-using Arc4u.Caching;
-using System.Text.Json;
-using Arc4u.Diagnostics;
 
 namespace Arc4u.OAuth2.DataProtection;
 
@@ -16,9 +16,9 @@ public class CacheStore : IXmlRepository
 {
     public CacheStore(IServiceProvider serviceProvider, ILoggerFactory loggerFactory, [DisallowNull] string cacheKey, string? cacheName = null)
     {
-        ArgumentNullException.ThrowIfNull(serviceProvider, nameof(serviceProvider));
-        ArgumentNullException.ThrowIfNull(loggerFactory, nameof(loggerFactory));
-        ArgumentNullException.ThrowIfNull(cacheKey, nameof(cacheKey));
+        ArgumentNullException.ThrowIfNull(serviceProvider);
+        ArgumentNullException.ThrowIfNull(loggerFactory);
+        ArgumentNullException.ThrowIfNull(cacheKey);
 
         _logger = loggerFactory.CreateLogger<CacheStore>();
         _serviceProvider = serviceProvider;

--- a/src/Arc4u.Standard.OAuth2.AspNetCore.Authentication/DataProtection/CacheStoreExtension.cs
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore.Authentication/DataProtection/CacheStoreExtension.cs
@@ -17,7 +17,7 @@ public static class CacheStoreExtension
         var validate = new CacheStoreOption();
         option(validate);
 
-        ArgumentNullException.ThrowIfNull(validate.CacheKey, nameof(validate.CacheKey));
+        ArgumentNullException.ThrowIfNull(validate.CacheKey);
 
         builder.Services.AddSingleton<IConfigureOptions<KeyManagementOptions>>(services =>
         {
@@ -33,12 +33,12 @@ public static class CacheStoreExtension
 
     public static IDataProtectionBuilder PersistKeysToCache(this IDataProtectionBuilder builder, [DisallowNull] IConfiguration configuration, [DisallowNull] string configSectionName = "DataProtectionStore")
     {
-        ArgumentNullException.ThrowIfNull(configuration, nameof(configuration));
+        ArgumentNullException.ThrowIfNull(configuration);
 
         return PersistKeysToCache(builder, PrepareAction(configuration, configSectionName));
     }
 
-    internal static Action<CacheStoreOption> PrepareAction(IConfiguration configuration ,string configSectionName)
+    internal static Action<CacheStoreOption> PrepareAction(IConfiguration configuration, string configSectionName)
     {
         var section = configuration.GetSection(configSectionName);
         if (!section.Exists())

--- a/src/Arc4u.Standard.OAuth2.AspNetCore.Authentication/Events/StandardCookieEvents.cs
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore.Authentication/Events/StandardCookieEvents.cs
@@ -32,8 +32,8 @@ public class StandardCookieEvents : CookieAuthenticationEvents
 
     public override async Task ValidatePrincipal(CookieValidatePrincipalContext cookieCtx)
     {
-        ArgumentNullException.ThrowIfNull(_serviceProvider, nameof(_serviceProvider));
-        ArgumentNullException.ThrowIfNull(_oidcOptions, nameof(_oidcOptions));
+        ArgumentNullException.ThrowIfNull(_serviceProvider);
+        ArgumentNullException.ThrowIfNull(_oidcOptions);
 
         var now = DateTimeOffset.UtcNow;
         var expiresAt = cookieCtx.Properties.GetTokenValue("expires_at");
@@ -57,7 +57,7 @@ public class StandardCookieEvents : CookieAuthenticationEvents
 
         if (timeRemaining < refreshThreshold)
         {
-            ArgumentNullException.ThrowIfNull(_tokenRefreshProvider, nameof(_tokenRefreshProvider));
+            ArgumentNullException.ThrowIfNull(_tokenRefreshProvider);
             try
             {
                 if (timeRemaining < TimeSpan.Zero)

--- a/src/Arc4u.Standard.OAuth2.AspNetCore.Authentication/Extensions/AuthenticationExtensions.cs
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore.Authentication/Extensions/AuthenticationExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using Arc4u.Configuration;
 using Arc4u.OAuth2.DataProtection;
 using Arc4u.OAuth2.Extensions;
 using Arc4u.OAuth2.Options;
@@ -162,8 +163,8 @@ public static partial class AuthenticationExtensions
 
     public static AuthenticationBuilder AddOidcAuthentication(this IServiceCollection services, IConfiguration configuration, [DisallowNull] string authenticationSectionName = "Authentication")
     {
-        ArgumentNullException.ThrowIfNull(configuration, nameof(configuration));
-        ArgumentNullException.ThrowIfNull(authenticationSectionName, nameof(authenticationSectionName));
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentNullException.ThrowIfNull(authenticationSectionName);
 
         var section = configuration.GetSection(authenticationSectionName);
 
@@ -174,35 +175,42 @@ public static partial class AuthenticationExtensions
 
         var settings = section.Get<OidcAuthenticationSectionOptions>() ?? throw new NullReferenceException($"No section exists with name {authenticationSectionName} in the configuration providers for OpenId Connect authentication.");
 
+        string? configErrors = null;
         if (string.IsNullOrWhiteSpace(settings.MetadataAddress))
         {
-            throw new MissingFieldException("MetadataAddress must be filled!");
+            configErrors += "MetadataAddress must be filled!" + System.Environment.NewLine;
         }
         if (string.IsNullOrWhiteSpace(settings.CookieName))
         {
-            throw new MissingFieldException("We need a cookie name defined specifically for your services.");
+            configErrors += "We need a cookie name defined specifically for your services." + System.Environment.NewLine;
         }
         if (string.IsNullOrWhiteSpace(settings.OpenIdSettingsSectionPath))
         {
-            throw new MissingFieldException("We need a setting section to configure the OpenId Connect.");
+            configErrors += "We need a setting section to configure the OpenId Connect." + System.Environment.NewLine;
         }
         if (string.IsNullOrWhiteSpace(settings.OAuth2SettingsSectionPath))
         {
-            throw new MissingFieldException("We need a setting section to configure OAuth2.");
+            configErrors += "We need a setting section to configure OAuth2." + System.Environment.NewLine;
         }
         if (string.IsNullOrWhiteSpace(settings.CertificateSectionPath))
         {
-            throw new MissingFieldException("We need a cookie name defined specifically for your services.");
+            configErrors += "We need a cookie name defined specifically for your services." + System.Environment.NewLine;
         }
         if (string.IsNullOrWhiteSpace(settings.DataProtectionSectionPath))
         {
-            throw new MissingFieldException("We need a setting section to configure the DataProtection cache store.");
+            configErrors += "We need a setting section to configure the DataProtection cache store." + System.Environment.NewLine;
         }
 
         if (string.IsNullOrWhiteSpace(settings.JwtBearerEventsType))
         {
-            throw new MissingFieldException("The JwtBearerEventsType must be defined.");
+            configErrors += "The JwtBearerEventsType must be defined." + System.Environment.NewLine;
         }
+
+        if (configErrors is not null)
+        {
+            throw new ConfigurationException(configErrors);
+        }
+
         var jwtBearerEventsType = Type.GetType(settings.JwtBearerEventsType, false);
 
         if (string.IsNullOrWhiteSpace(settings.CookieAuthenticationEventsType))
@@ -247,7 +255,7 @@ public static partial class AuthenticationExtensions
             options.ValidateAuthority = settings.ValidateAuthority;
             options.AuthenticationCacheTicketStoreOption = ticketStoreAction;
             options.OpenIdSettingsKey = settings.OpenIdSettingsKey;
-            options.OpenIdSettingsOptions = OpenIdSettingsExtension.PreapreAction(configuration, settings.OpenIdSettingsSectionPath);
+            options.OpenIdSettingsOptions = OpenIdSettingsExtension.PrepareAction(configuration, settings.OpenIdSettingsSectionPath);
             options.OAuth2SettingsKey = settings.OAuth2SettingsKey;
             options.OAuth2SettingsOptions = OAuth2SettingsExtension.PrepareAction(configuration, settings.OAuth2SettingsSectionPath);
             options.Certificate = cert;
@@ -276,8 +284,8 @@ public static partial class AuthenticationExtensions
     /// <returns></returns>
     public static AuthenticationBuilder AddJwtAuthentication(this IServiceCollection services, IConfiguration configuration, Action<JwtAuthenticationOptions> authenticationOptions)
     {
-        ArgumentNullException.ThrowIfNull(services, nameof(services));
-        ArgumentNullException.ThrowIfNull(authenticationOptions, nameof(authenticationOptions));
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(authenticationOptions);
 
         var options = new JwtAuthenticationOptions();
         authenticationOptions(options);
@@ -290,8 +298,8 @@ public static partial class AuthenticationExtensions
         var oauth2Options = new OAuth2SettingsOption();
         options.OAuth2SettingsOptions(oauth2Options);
 
-        ArgumentNullException.ThrowIfNull(options.JwtBearerEventsType, nameof(options.JwtBearerEventsType));
-        ArgumentNullException.ThrowIfNull(options.MetadataAddress, nameof(options.MetadataAddress));
+        ArgumentNullException.ThrowIfNull(options.JwtBearerEventsType);
+        ArgumentNullException.ThrowIfNull(options.MetadataAddress);
 
         services.ConfigureOAuth2Settings(options.OAuth2SettingsOptions, options.OAuth2SettingsKey);
 
@@ -325,8 +333,8 @@ public static partial class AuthenticationExtensions
 
     public static AuthenticationBuilder AddJwtAuthentication(this IServiceCollection services, IConfiguration configuration, [DisallowNull] string authenticationSectionName = "Authentication")
     {
-        ArgumentNullException.ThrowIfNull(configuration, nameof(configuration));
-        ArgumentNullException.ThrowIfNull(authenticationSectionName, nameof(authenticationSectionName));
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentNullException.ThrowIfNull(authenticationSectionName);
 
         var section = configuration.GetSection(authenticationSectionName);
 
@@ -375,8 +383,8 @@ public static partial class AuthenticationExtensions
     }
     //public static void ConfigureOpenIdAuthentication(this IServiceCollection services, IConfiguration configuration, Action<OidcAuthenticationOptions> options)
     //{
-    //    ArgumentNullException.ThrowIfNull(configuration, nameof(configuration));
-    //    ArgumentNullException.ThrowIfNull(options, nameof(options));
+    //    ArgumentNullException.ThrowIfNull(configuration);
+    //    ArgumentNullException.ThrowIfNull(options);
 
     //    var configData = new OidcAuthenticationOptions();
     //    options(configData);

--- a/src/Arc4u.Standard.OAuth2.AspNetCore.Authentication/Extensions/OAuth2SettingsExtension.cs
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore.Authentication/Extensions/OAuth2SettingsExtension.cs
@@ -11,34 +11,40 @@ public static class OAuth2SettingsExtension
 {
     public static SimpleKeyValueSettings ConfigureOAuth2Settings(this IServiceCollection services, Action<OAuth2SettingsOption> option, [DisallowNull] string sectionKey = "OAuth2")
     {
-        ArgumentNullException.ThrowIfNull(sectionKey, nameof(sectionKey));
+        ArgumentNullException.ThrowIfNull(sectionKey);
 
         var validate = new OAuth2SettingsOption();
         option(validate);
+        string? configErrors = null;
 
         if (string.IsNullOrWhiteSpace(validate.ProviderId))
         {
-            throw new MissingFieldException($"ProviderId field is not defined.");
+            configErrors += "ProviderId field is not defined." + System.Environment.NewLine;
         }
 
         if (string.IsNullOrWhiteSpace(validate.Audiences))
         {
-            throw new MissingFieldException($"Audiences field is not defined.");
+            configErrors += "Audiences field is not defined." + System.Environment.NewLine;
         }
 
         if (string.IsNullOrWhiteSpace(validate.Authority))
         {
-            throw new MissingFieldException($"Authorithy field is not defined.");
+            configErrors += "Authorithy field is not defined." + System.Environment.NewLine;
         }
 
         if (string.IsNullOrWhiteSpace(validate.ClientId))
         {
-            throw new MissingFieldException($"ClientId field is not defined.");
+            configErrors += "ClientId field is not defined." + System.Environment.NewLine;
         }
 
         if (string.IsNullOrWhiteSpace(validate.AuthenticationType))
         {
-            throw new MissingFieldException($"AuthenticationType field is not defined.");
+            configErrors += "AuthenticationType field is not defined." + System.Environment.NewLine;
+        }
+
+        if (configErrors is not null)
+        {
+            throw new ConfigurationException(configErrors);
         }
 
         // We map this to a IKeyValuesSettings dictionary.
@@ -70,7 +76,7 @@ public static class OAuth2SettingsExtension
 
     public static SimpleKeyValueSettings ConfigureOAuth2Settings(this IServiceCollection services, IConfiguration configuration, [DisallowNull] string sectionName, [DisallowNull] string sectionKey = "OAuth2")
     {
-        ArgumentNullException.ThrowIfNull(sectionKey, nameof(sectionKey));
+        ArgumentNullException.ThrowIfNull(sectionKey);
 
         return ConfigureOAuth2Settings(services, PrepareAction(configuration, sectionName), sectionKey);
     }

--- a/src/Arc4u.Standard.OAuth2.AspNetCore.Authentication/Extensions/OpenIdSettingsExtension.cs
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore.Authentication/Extensions/OpenIdSettingsExtension.cs
@@ -11,7 +11,7 @@ public static class OpenIdSettingsExtension
 {
     public static SimpleKeyValueSettings ConfigureOpenIdSettings(this IServiceCollection services, Action<OpenIdSettingsOption> option, [DisallowNull] string sectionKey = "OpenId")
     {
-        ArgumentNullException.ThrowIfNull(sectionKey, nameof(sectionKey));
+        ArgumentNullException.ThrowIfNull(sectionKey);
 
         var validate = new OpenIdSettingsOption();
         option(validate);
@@ -68,12 +68,12 @@ public static class OpenIdSettingsExtension
 
     public static SimpleKeyValueSettings ConfigureOpenIdSettings(this IServiceCollection services, IConfiguration configuration, [DisallowNull] string sectionName, [DisallowNull] string sectionKey = "OpenId")
     {
-        ArgumentNullException.ThrowIfNull(sectionKey, nameof(sectionKey));
+        ArgumentNullException.ThrowIfNull(sectionKey);
 
-        return ConfigureOpenIdSettings(services, PreapreAction(configuration, sectionName), sectionKey);
+        return ConfigureOpenIdSettings(services, PrepareAction(configuration, sectionName), sectionKey);
     }
 
-    internal static Action<OpenIdSettingsOption> PreapreAction(IConfiguration configuration, [DisallowNull] string sectionName)
+    internal static Action<OpenIdSettingsOption> PrepareAction(IConfiguration configuration, [DisallowNull] string sectionName)
     {
         if (string.IsNullOrEmpty(sectionName))
         {

--- a/src/Arc4u.Standard.OAuth2.AspNetCore.Authentication/Options/JwtAuthenticationSectionOptions.cs
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore.Authentication/Options/JwtAuthenticationSectionOptions.cs
@@ -7,7 +7,7 @@ public class JwtAuthenticationSectionOptions
 
     public string OAuth2SettingsKey { get; set; } = "OAuth2";
 
-    public string MetadataAddress { get; set; }
+    public string MetadataAddress { get; set; } = null!;
 
     public bool RequireHttpsMetadata { get; set; } = true;
 
@@ -15,5 +15,5 @@ public class JwtAuthenticationSectionOptions
 
     public string JwtBearerEventsType { get; set; } = typeof(StandardBearerEvents).AssemblyQualifiedName!;
 
-    public string? CertSecurityKeyPath { get; set; } = null;
+    public string? CertSecurityKeyPath { get; set; }
 }

--- a/src/Arc4u.Standard.OAuth2.AspNetCore.Authentication/TicketStore/CacheTicketStore.cs
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore.Authentication/TicketStore/CacheTicketStore.cs
@@ -13,8 +13,8 @@ public class CacheTicketStore : ITicketStore
 {
     public CacheTicketStore(ILogger<CacheTicketStore> logger, ICacheContext cacheContext, IOptionsMonitor<CacheTicketStoreOptions> options)
     {
-        ArgumentNullException.ThrowIfNull(options.CurrentValue.KeyPrefix, nameof(options.CurrentValue.KeyPrefix));
-        ArgumentNullException.ThrowIfNull(options.CurrentValue.CacheName, nameof(options.CurrentValue.CacheName));
+        ArgumentNullException.ThrowIfNull(options.CurrentValue.KeyPrefix);
+        ArgumentNullException.ThrowIfNull(options.CurrentValue.CacheName);
 
         _logger = logger;
         _cacheContext = cacheContext;

--- a/src/Arc4u.Standard.OAuth2.AspNetCore.Authentication/TicketStore/FileTicketStore.cs
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore.Authentication/TicketStore/FileTicketStore.cs
@@ -15,7 +15,7 @@ public class FileTicketStore : ITicketStore
     {
         _logger = logger;
 
-        ArgumentNullException.ThrowIfNull(options.CurrentValue.StorePath, nameof(options.CurrentValue.StorePath));
+        ArgumentNullException.ThrowIfNull(options.CurrentValue.StorePath);
 
         _directoryStore = options.CurrentValue.StorePath;
     }

--- a/src/Arc4u.Standard.OAuth2.AspNetCore.Authentication/Token/JwtHttpHandler.cs
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore.Authentication/Token/JwtHttpHandler.cs
@@ -34,7 +34,7 @@ public class JwtHttpHandler : DelegatingHandler
     {
         _container = container ?? throw new ArgumentNullException(nameof(container));
 
-        ArgumentNullException.ThrowIfNull(nameof(keyValuesSettingsOption));
+        ArgumentNullException.ThrowIfNull(keyValuesSettingsOption);
 
         _logger = logger;
 
@@ -48,7 +48,7 @@ public class JwtHttpHandler : DelegatingHandler
     {
         _accessor = accessor ?? throw new ArgumentNullException(nameof(accessor));
 
-        ArgumentNullException.ThrowIfNull(nameof(keyValuesSettingsOption));
+        ArgumentNullException.ThrowIfNull(keyValuesSettingsOption);
 
         _logger = logger;
 

--- a/src/Arc4u.Standard.OAuth2.AspNetCore.Authentication/TokenProviders/AzureADOboTokenProvider.cs
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore.Authentication/TokenProviders/AzureADOboTokenProvider.cs
@@ -47,8 +47,8 @@ public class AzureADOboTokenProvider : ITokenProvider
 
     public async Task<TokenInfo> GetTokenAsync(IKeyValueSettings settings, object platformParameters)
     {
-        ArgumentNullException.ThrowIfNull(_openIdConnectOptions, nameof(_openIdConnectOptions));
-        ArgumentNullException.ThrowIfNull(settings, nameof(settings));
+        ArgumentNullException.ThrowIfNull(_openIdConnectOptions);
+        ArgumentNullException.ThrowIfNull(settings);
 
         using var activity = _activitySource?.StartActivity("Get on behal of token", ActivityKind.Producer);
 

--- a/src/Arc4u.Standard.OAuth2.AspNetCore.Authentication/TokenProviders/BootstrapContextTokenProvider.cs
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore.Authentication/TokenProviders/BootstrapContextTokenProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Threading.Tasks;
@@ -34,9 +34,9 @@ public class BootstrapContextTokenProvider : ITokenProvider
     /// <returns><see cref="TokenInfo"/></returns>
     public Task<TokenInfo> GetTokenAsync(IKeyValueSettings settings, object platformParameters)
     {
-        ArgumentNullException.ThrowIfNull(settings, nameof(settings));
+        ArgumentNullException.ThrowIfNull(settings);
 
-        ArgumentNullException.ThrowIfNull(_applicationContext.Principal, nameof(_applicationContext.Principal));
+        ArgumentNullException.ThrowIfNull(_applicationContext.Principal);
 
         if (_applicationContext.Principal.Identity is ClaimsIdentity identity && !String.IsNullOrWhiteSpace(identity?.BootstrapContext?.ToString()))
         {

--- a/src/Arc4u.Standard.OAuth2.AspNetCore.Authentication/TokenProviders/OidcTokenProvider.cs
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore.Authentication/TokenProviders/OidcTokenProvider.cs
@@ -36,7 +36,7 @@ public class OidcTokenProvider : ITokenProvider
     /// <returns><see cref="TokenInfo"/></returns>
     public async Task<TokenInfo> GetTokenAsync(IKeyValueSettings settings, object platformParameters)
     {
-        ArgumentNullException.ThrowIfNull(settings, nameof(settings));
+        ArgumentNullException.ThrowIfNull(settings);
 
         var timeRemaining = _tokenRefreshInfo.AccessToken.ExpiresOnUtc.Subtract(DateTime.UtcNow);
 

--- a/src/Arc4u.Standard.OAuth2.AspNetCore.Authentication/TokenProviders/RefreshTokenProvider.cs
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore.Authentication/TokenProviders/RefreshTokenProvider.cs
@@ -48,9 +48,9 @@ public class RefreshTokenProvider : ITokenRefreshProvider
 
     public async Task<TokenInfo> GetTokenAsync(IKeyValueSettings settings, object platformParameters)
     {
-        ArgumentNullException.ThrowIfNull(_tokenRefreshInfo, nameof(_tokenRefreshInfo));
-        ArgumentNullException.ThrowIfNull(_openIdConnectOptions, nameof(_openIdConnectOptions));
-        ArgumentNullException.ThrowIfNull(_oidcOptions, nameof(_oidcOptions));
+        ArgumentNullException.ThrowIfNull(_tokenRefreshInfo);
+        ArgumentNullException.ThrowIfNull(_openIdConnectOptions);
+        ArgumentNullException.ThrowIfNull(_oidcOptions);
 
         using var activity = _activitySource?.StartActivity("Get on behal of token", ActivityKind.Producer);
 

--- a/src/Arc4u.Standard.gRPC/Interceptors/OAuth2/OAuth2Interceptor.cs
+++ b/src/Arc4u.Standard.gRPC/Interceptors/OAuth2/OAuth2Interceptor.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Security.Claims;
+using Arc4u.Configuration;
 using Arc4u.Dependency;
 using Arc4u.Diagnostics;
 using Arc4u.OAuth2.Token;
@@ -5,11 +8,8 @@ using Arc4u.Security.Principal;
 using Grpc.Core;
 using Grpc.Core.Interceptors;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Logging;
-using System;
-using System.Security.Claims;
 using Microsoft.Extensions.DependencyInjection;
-using Arc4u.Configuration;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Arc4u.gRPC.Interceptors
@@ -57,7 +57,7 @@ namespace Arc4u.gRPC.Interceptors
                 throw new ArgumentNullException(nameof(keyValuesSettingsOption));
             }
 #else
-            ArgumentNullException.ThrowIfNull(keyValuesSettingsOption, nameof(keyValuesSettingsOption));
+            ArgumentNullException.ThrowIfNull(keyValuesSettingsOption);
 #endif
             _accessor = accessor ?? throw new ArgumentNullException(nameof(accessor));
 


### PR DESCRIPTION
# Potential bug (not corrected):
- in CacheTicketStore.cs, the key prefix (_keyPrefix) isn't used anywhere: this might lead to problems in caching.


# Corrected:
## Threading bug in `CacheContext`
https://github.com/GFlisch/Arc4u.Guidance.Doc/issues/45 was corrected since the code was revisited anyway

## Inconsistent behavior when using ThrowIfNull/ThrowIfNullOrEmpty. 
For example (RedisCache.cs):

~~~csharp
#if NET6_0
        ArgumentNullException.ThrowIfNull(store, nameof(store));
#endif
#if NET7_0_OR_GREATER
        ArgumentNullException.ThrowIfNullOrEmpty(store, nameof(store));
#endif
~~~

This code has a different behavior depending on the version of .NET:
- on .NET 6, `store` can not be the null string, but can be the empty string
- on .NET 7 and later, `store` can not be null or empty

Also, C# 10 introduced [CallerArgumentExpression](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-10.0/caller-argument-expression) which makes the second argument `nameof(store)` unnecessary.
Finally, `ThrowIsNullOrEmpty` is a static member of (and throws an) `ArgumentException`, not `ArgumentNullException`. 
It works because the latter inherits from the former, but it's confusing to write it like this since that's not the exception that is thrown.

Presuming we want the most restrictive behavior (disallow null or empty strings), we keep the NET7_0_OR_GREATER behavior and test the classical way in all other cases.

~~~csharp
#if NET7_0_OR_GREATER
        ArgumentException.ThrowIfNullOrEmpty(store);
#else
        if (string.IsNullOrEmpty(store))
        {
            throw new ArgumentException("The value cannot be an empty string.", nameof(store));
        }
#endif
~~~
The exception message `"The value cannot be en empty string."` was chosen to be the same as the one thrown by ArgumentException.ThrowIfNullOrEmpty.
Strictly speaking, this is also behaviorally different, since the message of the argument exception will be different in localized versions of the .NET runtime.
I think the behavior is justifyable since it's only the exception's text message. Semanticallly, there is no behavioral difference.

Affects: `MemoryCache.cs`, `RedisCache.cs`, `SqlCache.cs`, `MemoryCacheExtension.cs`, `RedisCacheExtension.cs` and `SqlCacheExtension.cs`.
Note that for `RedisCacheExtension.cs` the test is used 3 times and was facotored out to avoid repetition.

## ArgumentNullException.ThrowIfNull isn't testing anything
In JwtHttpHandler.cs we see

~~~csharp
        ArgumentNullException.ThrowIfNull(nameof(keyValuesSettingsOption));
~~~

This is pointless because the argument is never null by definition. it is effectively not testing anything. 
It has been changed to:

~~~csharp
        ArgumentNullException.ThrowIfNull(keyValuesSettingsOption);
~~~

## Don't specify the `paramName` argument to ArgumentException.ThrowIfNull
This was already mentioned before: it's not needed to write:
~~~csharp
        ArgumentNullException.ThrowIfNull(options, nameof(options));
~~~

...since the value of the second parameter is captured by the caller argument expression.
The second parameter has been removed everywhere in the code.


## Environment instance built twice
The `ApplicationConfig` initializes the `Environment` twice:
~~~csharp
public class ApplicationConfig
{
    public ApplicationConfig() => Environment = new Environment();

     /// <summary>
    /// Name used to dentify the application when used externally other than logging!
    /// Cache or authorization, etc...
    /// </summary>
    public string ApplicationName { get; set; }

    public Environment Environment { get; set; } = new Environment();
}
~~~
This is a list properties for configuration, so I think we can leave the property init and get rid of the constructor.
The constructor has been removed.

## Improvement: report as many configuration errors at once
There is little more frustrating than correcting a configuration error, redeploying, and finding another one.
It therefore pays off to try and validate as many configuration issues in a single exception, so that as many of them can be corrected at once.

Instead of (`ConfigurationHelper.cs`):

~~~csharp
        if (string.IsNullOrEmpty(validate.ApplicationName))
        {
            throw new MissingFieldException("Application name is not defined in the intialization of the application config settings");
        }

        if (string.IsNullOrEmpty(validate.Environment.Name))
        {
            throw new MissingFieldException("Application environment name is not defined in the intialization of the application config settings");
        }

        if (string.IsNullOrEmpty(validate.Environment.LoggingName))
        {
            throw new MissingFieldException("Application environment logging name is not defined in the intialization of the application config settings");
        }

        if (string.IsNullOrEmpty(validate.Environment.TimeZone))
        {
            throw new MissingFieldException("Application environment time zone is not defined in the intialization of the application config settings");
        }
~~~

We can write:

~~~csharp
        // try to detect as many configuration errors as possible instead of stopping at the first misconfigured property.
        // since the happy flow is the norm, it's OK to use just a string to concatenate messages instead of a full-blown list or StringBuilder.

        string? configErrors = null;
        if (string.IsNullOrEmpty(validate.ApplicationName))
        {
            configErrors += "Application name is not defined in the intialization of the application config settings" + System.Environment.NewLine;
        }

        if (string.IsNullOrEmpty(validate.Environment.Name))
        {
            configErrors += "Application environment name is not defined in the intialization of the application config settings" + System.Environment.NewLine;
        }

        if (string.IsNullOrEmpty(validate.Environment.LoggingName))
        {
            configErrors += "Application environment logging name is not defined in the intialization of the application config settings" + System.Environment.NewLine;
        }

        if (string.IsNullOrEmpty(validate.Environment.TimeZone))
        {
            configErrors += "Application environment time zone is not defined in the intialization of the application config settings" + System.Environment.NewLine;
        }

        if (configErrors is not null)
	{
            throw new ConfigurationException(configErrors);
	}
~~~

A single exception will be thrown for all `ApplicationConfig` configuration value problems (if any).
That exception will not be a `MissingFieldException` (which is reflection-related), but a more appropriate `ConfigurationException` which is defined already anyway.

There is a similar issue in `AuthenticationExtensions.cs` and `OAuth2SettingsExtension.cs` (Arc4u.Standard.OAuth2.AspNetCore.Authentication).
There are other places as well when configuration settings are validated one by one. Perhaps we should define a general mechanism for it. I have a wonderful idea but the margin of this browser page is too small to contain it. This is for a next PR, maybe,.


## Small stuff
A method name called `PreapreAction` has been changed to `PrepareAction`.