### PR TITLE
Improve implementation of AttributeInspector and add documentation

### DIFF
--- a/src/Arc4u.Standard.Dependency/Attribute/ExportAttribute.cs
+++ b/src/Arc4u.Standard.Dependency/Attribute/ExportAttribute.cs
@@ -1,9 +1,21 @@
-﻿using System;
+using System;
 
 namespace Arc4u.Dependency.Attribute
 {
     /// <summary>
-    ///     Specifies that a type provides a particular export.
+    ///     Represents an attribute that indicates a type provides a specific export.
+    ///     This attribute can be used in combination with other attributes to define the export's lifetime:
+    ///     <list type="bullet">
+    ///         <item>
+    ///             <term><see cref="SharedAttribute"/></term>
+    ///             <description>Specifies that the export will have a singleton lifetime.</description>
+    ///         </item>
+    ///         <item>
+    ///             <term><see cref="ScopedAttribute"/></term>
+    ///             <description>Specifies that the export will have a scoped lifetime.</description>
+    ///         </item>
+    ///     </list>
+    ///     If neither <see cref="SharedAttribute"/> nor <see cref="ScopedAttribute"/> is used, the export will have a transient lifetime.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
     public class ExportAttribute : System.Attribute

--- a/src/Arc4u.Standard.Dependency/Attribute/ScopedAttribute.cs
+++ b/src/Arc4u.Standard.Dependency/Attribute/ScopedAttribute.cs
@@ -1,7 +1,10 @@
-﻿using System;
+using System;
 
 namespace Arc4u.Dependency.Attribute
 {
+    /// <summary>
+    /// Marks a class's lifetime as scoped (one instance by scope).
+    /// </summary>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
     public class ScopedAttribute : System.Attribute
     {
@@ -11,6 +14,5 @@ namespace Arc4u.Dependency.Attribute
         public ScopedAttribute()
         {
         }
-
     }
 }

--- a/src/Arc4u.Standard.Dependency/Attribute/SharedAttribute.cs
+++ b/src/Arc4u.Standard.Dependency/Attribute/SharedAttribute.cs
@@ -1,7 +1,10 @@
-﻿using System;
+using System;
 
 namespace Arc4u.Dependency.Attribute
 {
+    /// <summary>
+    /// Marks a class's lifetime as globally shared => singleton.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
     public class SharedAttribute : System.Attribute
     {

--- a/src/Arc4u.Standard.UnitTest/Dependency/AttributeInspectorTests.cs
+++ b/src/Arc4u.Standard.UnitTest/Dependency/AttributeInspectorTests.cs
@@ -1,0 +1,73 @@
+using System;
+using Arc4u.Dependency;
+using Arc4u.Dependency.Attribute;
+using Arc4u.Dependency.ComponentModel;
+using FluentAssertions;
+using Xunit;
+
+namespace Arc4u.Standard.UnitTest.Dependency;
+public class AttributeInspectorTests
+{
+    [Fact]
+    public void Registering_A_Instance_With_Export_And_Shared_Attributes_Registers_With_Singleton_Lifetime()
+    {
+        var container = new ComponentModelContainer();
+        var inspector = new AttributeInspector(container);
+        inspector.Register(typeof(SingletonObject));
+        container.CreateContainer();
+
+        var instance = container.Resolve<ISingletonObject>();
+        var instance2 = container.Resolve<ISingletonObject>();
+
+        instance.Should().BeSameAs(instance2);
+    }
+
+    [Fact]
+    public void Registering_A_Instance_With_Export_And_Scoped_Attributes_Registers_With_Scoped_Lifetime()
+    {
+        var container = new ComponentModelContainer();
+        var inspector = new AttributeInspector(container);
+        inspector.Register(typeof(ScopedObject));
+        container.CreateContainer();
+
+        // With a scope, the instances are different.
+        var scope1 = container.CreateScope();
+        var scope2 = container.CreateScope();
+        var instance1 = scope1.Resolve<IScopedObject>();
+        var instance2 = scope2.Resolve<IScopedObject>();
+        instance1.Should().NotBeNull();
+        instance1.Should().NotBeSameAs(instance2);
+
+        // Without any scope, the instance is the same.
+        var instance3 = container.Resolve<IScopedObject>();
+        var instance4 = container.Resolve<IScopedObject>();
+        instance3.Should().BeSameAs(instance4);
+    }
+
+    [Fact]
+    public void Registering_A_Instance_With_Only_Export_Registers_With_Transient_Lifetime()
+    {
+        var container = new ComponentModelContainer();
+        var inspector = new AttributeInspector(container);
+        inspector.Register(typeof(TransientObject));
+        container.CreateContainer();
+
+        var instance1 = container.Resolve<ITransientObject>();
+        var instance2 = container.Resolve<ITransientObject>();
+
+        instance1.Should().NotBeNull();
+        instance1.Should().NotBeSameAs(instance2);
+    }
+}
+
+[Export(typeof(ITransientObject))]
+public class TransientObject : ITransientObject {}
+public interface ITransientObject {}
+
+[Export(typeof(IScopedObject)), Scoped]
+public class ScopedObject : IScopedObject {}
+public interface IScopedObject {}
+
+[Export(typeof(ISingletonObject)), Shared]
+public class SingletonObject : ISingletonObject {}
+public interface ISingletonObject {}

--- a/src/Arc4u.Standard.UnitTest/DependencyTests.cs
+++ b/src/Arc4u.Standard.UnitTest/DependencyTests.cs
@@ -1,4 +1,4 @@
-﻿using Arc4u.Configuration;
+using Arc4u.Configuration;
 using Arc4u.Dependency;
 using Arc4u.Dependency.Attribute;
 using Arc4u.Dependency.ComponentModel;
@@ -687,7 +687,7 @@ namespace Arc4u.Standard.UnitTest
         public Guid Id => _id;
     }
 
-    [Export(typeof(IGenerator)), Dependency.Attribute.Scoped]
+    [Export(typeof(IGenerator)), Scoped]
     [Export]
     public class TestScopedParser : IGenerator
     {


### PR DESCRIPTION
The AttributeInspector class determines the lifetime when registering classes. Previously, it checked if SharedAttribute or ScopedAttribute were declared or if neither of the two were present. This check was performed using the AttributeType.Name as a hardcoded string, which yielded no results when attempting to "Show usage." This commit resolves this issue by utilizing the actual SharedAttribute and ScopedAttribute types.

Furthermore, additional documentation has been provided to clarify the registration process, and several unit tests have been incorporated to ensure correct functionality.