### PR TITLE
Replace bunch of string concatenation with usage of StringBulder

### DIFF
--- a/src/Arc4u.Standard.Configuration/Configuration/ConfigurationHelper.cs
+++ b/src/Arc4u.Standard.Configuration/Configuration/ConfigurationHelper.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using System.Text;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -77,31 +78,31 @@ public static class ConfigurationHelper
 
         // try to detect as many configuration errors as possible instead of stopping at the first misconfigured property.
         // since the happy flow is the norm, it's OK to use just a string to concatenate messages instead of a full-blown list or StringBuilder.
+        var configErrorsStringBuilder = new StringBuilder();
 
-        string? configErrors = null;
         if (string.IsNullOrEmpty(validate.ApplicationName))
         {
-            configErrors += "Application name is not defined in the intialization of the application config settings" + System.Environment.NewLine;
+            configErrorsStringBuilder.AppendLine("Application name is not defined in the initialization of the application config settings");
         }
 
         if (string.IsNullOrEmpty(validate.Environment.Name))
         {
-            configErrors += "Application environment name is not defined in the intialization of the application config settings" + System.Environment.NewLine;
+            configErrorsStringBuilder.AppendLine("Application environment name is not defined in the initialization of the application config settings");
         }
 
         if (string.IsNullOrEmpty(validate.Environment.LoggingName))
         {
-            configErrors += "Application environment logging name is not defined in the intialization of the application config settings" + System.Environment.NewLine;
+            configErrorsStringBuilder.AppendLine("Application environment logging name is not defined in the initialization of the application config settings");
         }
 
         if (string.IsNullOrEmpty(validate.Environment.TimeZone))
         {
-            configErrors += "Application environment time zone is not defined in the intialization of the application config settings" + System.Environment.NewLine;
+            configErrorsStringBuilder.AppendLine("Application environment time zone is not defined in the initialization of the application config settings");
         }
 
-        if (configErrors is not null)
+        if (configErrorsStringBuilder.Length > 0)
         {
-            throw new ConfigurationException(configErrors);
+            throw new ConfigurationException(configErrorsStringBuilder.ToString());
         }
 
         services.Configure<ApplicationConfig>(option);

--- a/src/Arc4u.Standard.OAuth2.AspNetCore.Authentication/Extensions/OAuth2SettingsExtension.cs
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore.Authentication/Extensions/OAuth2SettingsExtension.cs
@@ -15,31 +15,30 @@ public static class OAuth2SettingsExtension
 
         var validate = new OAuth2SettingsOption();
         option(validate);
-        string? configErrors = null;
 
+        var configErrorsStringBuilder = new System.Text.StringBuilder();
         if (string.IsNullOrWhiteSpace(validate.ProviderId))
         {
-            configErrors += "ProviderId field is not defined." + System.Environment.NewLine;
+            configErrorsStringBuilder.AppendLine("ProviderId field is not defined.");
         }
 
         if (string.IsNullOrWhiteSpace(validate.Audiences))
         {
-            configErrors += "Audiences field is not defined." + System.Environment.NewLine;
+            configErrorsStringBuilder.AppendLine("Audiences field is not defined.");
         }
 
         if (string.IsNullOrWhiteSpace(validate.AuthenticationType))
         {
-            configErrors += "AuthenticationType field is not defined." + System.Environment.NewLine;
+            configErrorsStringBuilder.AppendLine("AuthenticationType field is not defined.");
         }
 
-        if (configErrors is not null)
+        if (configErrorsStringBuilder.Length > 0)
         {
-            throw new ConfigurationException(configErrors);
+            throw new ConfigurationException(configErrorsStringBuilder.ToString());
         }
 
         // We map this to a IKeyValuesSettings dictionary.
         // The TokenProviders are based on this.
-
         void SettingsFiller(SimpleKeyValueSettings keyOptions)
         {
             keyOptions.Add(TokenKeys.ProviderIdKey, validate!.ProviderId);
@@ -49,7 +48,6 @@ public static class OAuth2SettingsExtension
             if (!string.IsNullOrWhiteSpace(validate.Authority))
             {
                 keyOptions.Add(TokenKeys.AuthorityKey, validate.Authority);
-
             }
             keyOptions.Add(TokenKeys.Audiences, validate.Audiences);
             if (!string.IsNullOrWhiteSpace(validate.Scopes))
@@ -58,7 +56,6 @@ public static class OAuth2SettingsExtension
             }
         }
 
-
         services.Configure<SimpleKeyValueSettings>(sectionKey, SettingsFiller);
 
         var settings = new SimpleKeyValueSettings();
@@ -66,7 +63,6 @@ public static class OAuth2SettingsExtension
         SettingsFiller(settings);
 
         return settings;
-
     }
 
     public static SimpleKeyValueSettings ConfigureOAuth2Settings(this IServiceCollection services, IConfiguration configuration, [DisallowNull] string sectionName, [DisallowNull] string sectionKey = "OAuth2")

--- a/src/Arc4u.Standard.OAuth2.AspNetCore.Authentication/Extensions/OnBehalfOfAuthenticationExtensions.cs
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore.Authentication/Extensions/OnBehalfOfAuthenticationExtensions.cs
@@ -78,25 +78,25 @@ public static class OnBehalfOfAuthenticationExtensions
         var extract = new OnBehalfOfSettingsOptions();
         options(extract);
 
-        var configErrors = string.Empty;
+        var configErrorsStringBuilder = new System.Text.StringBuilder();
         if (string.IsNullOrWhiteSpace(extract.ClientId))
         {
-            configErrors += "ClientId field is not defined." + System.Environment.NewLine;
+            configErrorsStringBuilder.AppendLine("ClientId field is not defined.");
         }
 
         if (string.IsNullOrWhiteSpace(extract.ApplicationKey))
         {
-            configErrors += "ApplicationKey field is not defined." + System.Environment.NewLine;
+            configErrorsStringBuilder.AppendLine("ApplicationKey field is not defined.");
         }
 
         if (string.IsNullOrWhiteSpace(extract.Scope))
         {
-            configErrors += "Scope field is not defined." + System.Environment.NewLine;
+            configErrorsStringBuilder.AppendLine("Scope field is not defined.");
         }
 
-        if (!string.IsNullOrWhiteSpace(configErrors))
+        if (configErrorsStringBuilder.Length > 0)
         {
-            throw new ConfigurationException(configErrors);
+            throw new ConfigurationException(configErrorsStringBuilder.ToString());
         }
 
         return extract;

--- a/src/Arc4u.Standard.OAuth2.AspNetCore/Extensions/RemoteSecretsExtension.cs
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore/Extensions/RemoteSecretsExtension.cs
@@ -61,25 +61,26 @@ public static class RemoteSecretsExtension
     {
         // Check the settings!
         // options mandatory fields!
-        string? configErrors = null;
+        var configErrorsStringBuilder = new System.Text.StringBuilder();
+
         if (string.IsNullOrWhiteSpace(options.HeaderKey))
         {
-            configErrors += "HeaaderKey in Remote Secret settings must be filled!" + System.Environment.NewLine;
+            configErrorsStringBuilder.AppendLine("HeaderKey in Remote Secret settings must be filled!");
         }
 
         if (string.IsNullOrWhiteSpace(options.ClientSecret))
         {
-            configErrors += "ClientSecret in Remote Secret settings must be filled!" + System.Environment.NewLine;
+            configErrorsStringBuilder.AppendLine("ClientSecret in Remote Secret settings must be filled!");
         }
 
         if (string.IsNullOrWhiteSpace(options.ProviderId))
         {
-            configErrors += "ProviderId in Remote Secret settings must be filled!" + System.Environment.NewLine;
+            configErrorsStringBuilder.AppendLine("ProviderId in Remote Secret settings must be filled!");
         }
 
-        if (configErrors is not null)
+        if (configErrorsStringBuilder.Length > 0)
         {
-            throw new ConfigurationException(configErrors);
+            throw new ConfigurationException(configErrorsStringBuilder.ToString());
         }
 
         // We map this to a IKeyValuesSettings dictionary.

--- a/src/Arc4u.Standard.OAuth2.AspNetCore/Extensions/SecretBasicExtension.cs
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore/Extensions/SecretBasicExtension.cs
@@ -57,67 +57,72 @@ public static class SecretBasicExtension
     }
     private static Action<SimpleKeyValueSettings> BuildBasicSettings(SecretBasicSettingsOptions options)
     {
+        var configErrorsStringBuilder = new System.Text.StringBuilder();
+
         // Check the settings!
         // options mandatory fields!
-        string? configErrors = null;
+
         if (string.IsNullOrWhiteSpace(options.ClientId))
         {
-            configErrors += "ClientId in Secret Basic settings must be filled!" + System.Environment.NewLine;
+            configErrorsStringBuilder.AppendLine("ClientId in Secret Basic settings must be filled!");
         }
 
         if (string.IsNullOrWhiteSpace(options.Authority))
         {
-            configErrors += "Authority in Secret Basic settings must be filled!" + System.Environment.NewLine;
+            configErrorsStringBuilder.AppendLine("Authority in Secret Basic settings must be filled!");
         }
 
         if (string.IsNullOrWhiteSpace(options.Audience))
         {
-            configErrors += "Audience in Secret Basic settings must be filled!" + System.Environment.NewLine;
+            configErrorsStringBuilder.AppendLine("Audience in Secret Basic settings must be filled!");
         }
 
         if (string.IsNullOrWhiteSpace(options.AuthenticationType))
         {
-            configErrors += "AuthenticationType in Secret Basic settings must be filled!" + System.Environment.NewLine;
+            configErrorsStringBuilder.AppendLine("AuthenticationType in Secret Basic settings must be filled!");
         }
 
         if (string.IsNullOrWhiteSpace(options.ProviderId))
         {
-            configErrors += "ProviderId in Secret Basic settings must be filled!" + System.Environment.NewLine;
+            configErrorsStringBuilder.AppendLine("ProviderId in Secret Basic settings must be filled!");
         }
 
         if (string.IsNullOrWhiteSpace(options.Scope))
         {
-            configErrors += "Scope in Secret Basic settings must be filled!" + System.Environment.NewLine;
+            configErrorsStringBuilder.AppendLine("Scope in Secret Basic settings must be filled!");
         }
 
         if (string.IsNullOrWhiteSpace(options.BasicProviderId))
         {
-            configErrors += "BasicProviderId in Secret Basic settings must be filled!" + System.Environment.NewLine;
+            configErrorsStringBuilder.AppendLine(
+                "BasicProviderId in Secret Basic settings must be filled!");
         }
 
-        if (string.IsNullOrWhiteSpace(options.User) && string.IsNullOrWhiteSpace(options.Password) && string.IsNullOrWhiteSpace(options.Credential))
+        if (string.IsNullOrWhiteSpace(options.User) &&
+            string.IsNullOrWhiteSpace(options.Password) &&
+            string.IsNullOrWhiteSpace(options.Credential))
         {
-            configErrors += "User/Password or Credential in Secret Basic settings must be filled!" + System.Environment.NewLine;
+            configErrorsStringBuilder.AppendLine("User/Password or Credential in Secret Basic settings must be filled!");
         }
 
         if (!string.IsNullOrWhiteSpace(options.Password) && !string.IsNullOrWhiteSpace(options.Credential))
         {
-            configErrors += "Password and Credential in Secret Basic settings cannot be filled at the same time!" + System.Environment.NewLine;
+            configErrorsStringBuilder.AppendLine(
+                               "Password and Credential in Secret Basic settings cannot be filled at the same time!");
         }
 
         if (string.IsNullOrWhiteSpace(options.User) && !string.IsNullOrWhiteSpace(options.Password) && string.IsNullOrWhiteSpace(options.Credential))
         {
-            configErrors += "User in Secret Basic settings must be filled when password is used!" + System.Environment.NewLine;
+            configErrorsStringBuilder.AppendLine("User in Secret Basic settings must be filled when password is used!");
         }
 
-        if (configErrors is not null)
+        if (configErrorsStringBuilder.Length > 0)
         {
-            throw new ConfigurationException(configErrors);
+            throw new ApplicationException(configErrorsStringBuilder.ToString());
         }
 
         // We map this to a IKeyValuesSettings dictionary.
         // The TokenProviders are based on this.
-
         void Settings(SimpleKeyValueSettings settings)
         {
             settings.Add(TokenKeys.ProviderIdKey, options!.ProviderId);

--- a/src/Arc4u.Standard.OAuth2.AspNetCore/Middleware/BasicAuthenticationMiddlewareExtension.cs
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore/Middleware/BasicAuthenticationMiddlewareExtension.cs
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography.X509Certificates;
+using System.Text;
 using System.Text.RegularExpressions;
 
 namespace Arc4u.Standard.OAuth2.Middleware;
@@ -34,20 +35,20 @@ public static class BasicAuthenticationMiddlewareExtension
 
         var settings = section.Get<BasicAuthenticationConfigurationSectionOptions>() ?? throw new NullReferenceException($"No section exists with name {sectionName} in the configuration providers for Basic authentication.");
 
-        string? configErrors = null;
+        var configErrorsStringBuilder = new StringBuilder();
         if (string.IsNullOrWhiteSpace(settings.BasicSettingsPath))
         {
-            configErrors += "BasicSettingsPath must be filled!" + System.Environment.NewLine;
+            configErrorsStringBuilder.AppendLine("BasicSettingsPath must be filled!");
         }
 
         if (string.IsNullOrWhiteSpace(settings.CertificateHeaderPath))
         {
-            configErrors += "CertificateHeaderPath must be filled!" + System.Environment.NewLine;
+            configErrorsStringBuilder.AppendLine("CertificateHeaderPath must be filled!");
         }
 
-        if (configErrors is not null)
+        if (configErrorsStringBuilder.Length > 0)
         {
-            throw new ConfigurationException(configErrors);
+            throw new ConfigurationException(configErrorsStringBuilder.ToString());
         }
 
         certificateLoader ??= new X509CertificateLoader(null);
@@ -58,7 +59,6 @@ public static class BasicAuthenticationMiddlewareExtension
             options.BasicOptions = PrepareBasicAction(configuration, settings.BasicSettingsPath);
             options.CertificateHeaderOptions = PrepareCertificatesAction(configuration, settings.CertificateHeaderPath, certificateLoader);
         });
-
     }
 
     public static void AddBasicAuthenticationSettings(this IServiceCollection services, Action<BasicAuthenticationConfigurationOptions> options)
@@ -102,41 +102,42 @@ public static class BasicAuthenticationMiddlewareExtension
     {
         var validate = new BasicSettingsOptions();
         options(validate);
-        var configErrors = string.Empty;
+
+        var configErrorsStringBuilder = new StringBuilder();
 
         if (string.IsNullOrWhiteSpace(validate.ProviderId))
         {
-            configErrors += "ProviderId field is not defined." + System.Environment.NewLine;
+            configErrorsStringBuilder.AppendLine("ProviderId field is not defined.");
         }
 
         if (string.IsNullOrWhiteSpace(validate.Audience))
         {
-            configErrors += "Audiences field is not defined." + System.Environment.NewLine;
+            configErrorsStringBuilder.AppendLine("Audiences field is not defined.");
         }
 
         if (string.IsNullOrWhiteSpace(validate.Authority))
         {
-            configErrors += "Authorithy field is not defined." + System.Environment.NewLine;
+            configErrorsStringBuilder.AppendLine("Authorithy field is not defined.");
         }
 
         if (string.IsNullOrWhiteSpace(validate.ClientId))
         {
-            configErrors += "ClientId field is not defined." + System.Environment.NewLine;
+            configErrorsStringBuilder.AppendLine("ClientId field is not defined.");
         }
 
         if (string.IsNullOrWhiteSpace(validate.AuthenticationType))
         {
-            configErrors += "AuthenticationType field is not defined." + System.Environment.NewLine;
+            configErrorsStringBuilder.AppendLine("AuthenticationType field is not defined.");
         }
 
         if (string.IsNullOrWhiteSpace(validate.Scope))
         {
-            configErrors += "Scope field is not defined." + System.Environment.NewLine;
+            configErrorsStringBuilder.AppendLine("Scope field is not defined.");
         }
 
-        if (!string.IsNullOrWhiteSpace(configErrors))
+        if (configErrorsStringBuilder.Length > 0)
         {
-            throw new ConfigurationException(configErrors);
+            throw new ConfigurationException(configErrorsStringBuilder.ToString());
         }
 
         // We map this to a IKeyValuesSettings dictionary.
@@ -207,41 +208,40 @@ public static class BasicAuthenticationMiddlewareExtension
         var settings = section.Get<BasicSettingsOptions>() ?? throw new NullReferenceException($"No section exists with name {sectionName}");
 
         // Validate mandatory fields!
-        string? configErrors = null;
+        var configErrorsStringBuilder = new StringBuilder();
         if (string.IsNullOrWhiteSpace(settings.ClientId))
         {
-            configErrors += "ClientId in Basic settings must be filled!" + System.Environment.NewLine;
+            configErrorsStringBuilder.AppendLine("ClientId in Basic settings must be filled!");
         }
 
         if (string.IsNullOrWhiteSpace(settings.Authority))
         {
-            configErrors += "Authority in Basic settings must be filled!" + System.Environment.NewLine;
+            configErrorsStringBuilder.AppendLine("Authority in Basic settings must be filled!");
         }
 
         if (string.IsNullOrWhiteSpace(settings.Audience))
         {
-            configErrors += "Audience in Basic settings must be filled!" + System.Environment.NewLine;
+            configErrorsStringBuilder.AppendLine("Audience in Basic settings must be filled!");
         }
 
         if (string.IsNullOrWhiteSpace(settings.AuthenticationType))
         {
-            configErrors += "AuthenticationType in Basic settings must be filled!" + System.Environment.NewLine;
+            configErrorsStringBuilder.AppendLine("AuthenticationType in Basic settings must be filled!");
         }
 
         if (string.IsNullOrWhiteSpace(settings.ProviderId))
         {
-            configErrors += "ProviderId in Basic settings must be filled!" + System.Environment.NewLine;
+            configErrorsStringBuilder.AppendLine("ProviderId in Basic settings must be filled!");
         }
 
         if (string.IsNullOrWhiteSpace(settings.Scope))
         {
-            configErrors += "Scope in Basic settings must be filled!" + System.Environment.NewLine;
+            configErrorsStringBuilder.AppendLine("Scope in Basic settings must be filled!");
         }
 
-
-        if (configErrors is not null)
+        if (configErrorsStringBuilder.Length > 0)
         {
-            throw new ConfigurationException(configErrors);
+            throw new ConfigurationException(configErrorsStringBuilder.ToString());
         }
 
         void OptionFiller(BasicSettingsOptions option)

--- a/src/Arc4u.Standard.OAuth2.AspNetCore/Middleware/OpenIdBearerInjectorMiddlewareExtension.cs
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore/Middleware/OpenIdBearerInjectorMiddlewareExtension.cs
@@ -18,24 +18,23 @@ public static class OpenIdBearerInjectorMiddlewareExtension
         var validate = new OpenIdBearerInjectorOptions();
         options(validate);
 
-        string? configErrors = null;
+        var configErrorsStringBuilder = new System.Text.StringBuilder();
         if (string.IsNullOrEmpty(validate.OnBehalfOfOpenIdSettingsKey))
         {
-            configErrors += "The on behalf of settings key must be defined." + System.Environment.NewLine;
+            configErrorsStringBuilder.AppendLine("The on behalf of settings key must be defined.");
         }
 
         if (string.IsNullOrEmpty(validate.OboProviderKey))
         {
-            configErrors += "The token provider key to handle the on behalf of scenario must be defined." + System.Environment.NewLine;
+            configErrorsStringBuilder.AppendLine("The token provider key to handle the on behalf of scenario must be defined.");
         }
 
-        if (configErrors is not null)
+        if (configErrorsStringBuilder.Length > 0)
         {
-            throw new ConfigurationException(configErrors);
+            throw new ConfigurationException(configErrorsStringBuilder.ToString());
         }
 
         services.Configure<OpenIdBearerInjectorOptions>(options);
-
     }
 
     public static void AddOpenIdBearerInjector(this IServiceCollection services)
@@ -44,20 +43,20 @@ public static class OpenIdBearerInjectorMiddlewareExtension
 
         var validate = new OpenIdBearerInjectorOptions();
 
-        string? configErrors = null;
+        var configErrorsStringBuilder = new System.Text.StringBuilder();
         if (string.IsNullOrEmpty(validate.OnBehalfOfOpenIdSettingsKey))
         {
-            configErrors += "The on behalf of settings key must be defined." + System.Environment.NewLine;
+            configErrorsStringBuilder.AppendLine("The on behalf of settings key must be defined.");
         }
 
         if (string.IsNullOrEmpty(validate.OboProviderKey))
         {
-            configErrors += "The token provider key to handle the on behalf of scenario must be defined." + System.Environment.NewLine;
+            configErrorsStringBuilder.AppendLine("The token provider key to handle the on behalf of scenario must be defined.");
         }
 
-        if (configErrors is not null)
+        if (configErrorsStringBuilder.Length > 0)
         {
-            throw new ConfigurationException(configErrors);
+            throw new ConfigurationException(configErrorsStringBuilder.ToString());
         }
 
         services.AddOpenIdBearerInjector(options =>
@@ -66,7 +65,6 @@ public static class OpenIdBearerInjectorMiddlewareExtension
             options.OnBehalfOfOpenIdSettingsKey = validate.OnBehalfOfOpenIdSettingsKey;
             options.OpenIdSettingsKey = validate.OpenIdSettingsKey;
         });
-
     }
 
     public static IApplicationBuilder UseOpenIdBearerInjector([DisallowNull] this IApplicationBuilder app)


### PR DESCRIPTION
This commit aims to prevent unnecessary string concatenation.

While the choice of using a `StringBuilder` was made, there are alternatives:
- a `List<string>` that gets flattened with `string.Join`: now this method uses vectorization which makes its performance close to the `StringBuilder`
- Arcu's `Message(s)`

