### PR TITLE
Remove redundant 'else' in the solution

### DIFF
--- a/src/Arc4u.Standard.OAuth2.AspNetCore.Adal/TokenProvider/AdalTokenProvider.cs
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore.Adal/TokenProvider/AdalTokenProvider.cs
@@ -73,7 +73,7 @@ public abstract class AdalTokenProvider : ITokenProvider
                                      out string clientId,
                                      out Uri redirectUri);
 
-        
+
         AuthenticationResult result = null;
         if (null != credential)
         {
@@ -92,7 +92,7 @@ public abstract class AdalTokenProvider : ITokenProvider
         }
 
         // we don't have a result!
-        throw new NullReferenceException(nameof(result));           
+        throw new NullReferenceException(nameof(result));
     }
 
 
@@ -166,17 +166,15 @@ public abstract class AdalTokenProvider : ITokenProvider
 
             throw new NullReferenceException(nameof(credential));
         }
-        else
-        {
-            var objectId = _userCacheKeyIdentifier.GetIdentifer(identity);
-            if (String.IsNullOrWhiteSpace(objectId))
-            {
-                messages.Add(new Message(Arc4u.ServiceModel.MessageCategory.Technical, Arc4u.ServiceModel.MessageType.Error, "No user object identifier is found in the claims collection to identify the user."));
-                messages.LogAndThrowIfNecessary(_logger);
-            }
 
-            userObjectId = objectId!;
+        var objectId = _userCacheKeyIdentifier.GetIdentifer(identity);
+        if (String.IsNullOrWhiteSpace(objectId))
+        {
+            messages.Add(new Message(Arc4u.ServiceModel.MessageCategory.Technical, Arc4u.ServiceModel.MessageType.Error, "No user object identifier is found in the claims collection to identify the user."));
+            messages.LogAndThrowIfNecessary(_logger);
         }
+
+        userObjectId = objectId!;
 
         var authContext = CreateAuthenticationContext(authority, serviceApplicationId + settings.Values[TokenKeys.AuthenticationTypeKey] + userObjectId);
         _logger.Technical().System("Created the authentication context.").Log();

--- a/src/Arc4u.Standard.OAuth2.AspNetCore.Adal/TokenProvider/Obo/AdalOboTokenProvider.cs
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore.Adal/TokenProvider/Obo/AdalOboTokenProvider.cs
@@ -86,8 +86,8 @@ public abstract class AdalOboTokenProvider : ITokenProvider
                 {
                     return await openIdTokenProvider.GetTokenAsync(openIdSettings, identity);
                 }
-                else
-                    messages.Add(new Message(ServiceModel.MessageCategory.Technical, MessageType.Error, $"Cannot resolve a token provider with name {tokenProviderName}."));
+
+                messages.Add(new Message(ServiceModel.MessageCategory.Technical, MessageType.Error, $"Cannot resolve a token provider with name {tokenProviderName}."));
             }
         }
         else

--- a/src/Arc4u.Standard.OAuth2.AspNetCore.Blazor/BlazorController.cs
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore.Blazor/BlazorController.cs
@@ -82,10 +82,8 @@ namespace Arc4u.Blazor
                 var thisController = settings.Values[TokenKeys.RootServiceUrlKey].TrimEnd('/') + $"/blazor/redirectto/{redirectTo}/{index + 1}&token={accessToken.Substring((index - 1) * buffer, buffer)}";
                 return Redirect(UriHelper.Encode(new Uri($"{redirectUri}?url={thisController}")));
             }
-            else
-            {
-                return Redirect($"{redirectUri}?token={accessToken.Substring((index - 1) * buffer, accessToken.Length - (index - 1) * buffer)}");
-            }
+
+            return Redirect($"{redirectUri}?token={accessToken.Substring((index - 1) * buffer, accessToken.Length - (index - 1) * buffer)}");
         }
     }
 }

--- a/src/Arc4u.Standard.Serializer.JSon/JsonCompressedStreamSerializationBase.cs
+++ b/src/Arc4u.Standard.Serializer.JSon/JsonCompressedStreamSerializationBase.cs
@@ -59,18 +59,16 @@ namespace Arc4u.Serializer
 
         protected T InternalDeserialize<T>(Stream utf8json)
         {
-            if (_context != null)
-                return (T)JsonSerializer.Deserialize(utf8json, typeof(T), _context);
-            else
-                return JsonSerializer.Deserialize<T>(utf8json, _options);
+            return _context != null
+                ? (T)JsonSerializer.Deserialize(utf8json, typeof(T), _context)
+                : JsonSerializer.Deserialize<T>(utf8json, _options);
         }
 
         protected object InternalDeserialize(Stream utf8json, Type returnType)
         {
-            if (_context != null)
-                return JsonSerializer.Deserialize(utf8json, returnType, _context);
-            else
-                return JsonSerializer.Deserialize(utf8json, returnType, _options);
+            return _context != null
+                ? JsonSerializer.Deserialize(utf8json, returnType, _context)
+                : JsonSerializer.Deserialize(utf8json, returnType, _options);
         }
     }
 }

--- a/src/Arc4u.Standard.Serializer.JSon/JsonSerialization.cs
+++ b/src/Arc4u.Standard.Serializer.JSon/JsonSerialization.cs
@@ -28,7 +28,6 @@ namespace Arc4u.Serializer
             _options = options;
         }
 
-
         /// <summary>
         /// Construct an instance with a serialization context.
         /// This is used for source generation, implemented in .NET 6 or later (https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/source-generation?pivots=dotnet-6-0)
@@ -39,36 +38,31 @@ namespace Arc4u.Serializer
             _context = context;
         }
 
-
         public byte[] Serialize<T>(T value)
         {
             Activity.Current?.SetTag("SerializerType", "Json");
 
-            if (_context != null)
-                return JsonSerializer.SerializeToUtf8Bytes(value, typeof(T), _context);
-            else
-                return JsonSerializer.SerializeToUtf8Bytes(value, _options);
+            return _context != null
+                ? JsonSerializer.SerializeToUtf8Bytes(value, typeof(T), _context)
+                : JsonSerializer.SerializeToUtf8Bytes(value, _options);
         }
 
         public T Deserialize<T>(byte[] data)
         {
             Activity.Current?.SetTag("SerializerType", "Json");
 
-            if (_context != null)
-                return (T)JsonSerializer.Deserialize(data, typeof(T), _context);
-            else
-                return JsonSerializer.Deserialize<T>(data, _options);
+            return _context != null
+                ? (T)JsonSerializer.Deserialize(data, typeof(T), _context)
+                : JsonSerializer.Deserialize<T>(data, _options);
         }
-
 
         public object Deserialize(byte[] data, Type objectType)
         {
             Activity.Current?.SetTag("SerializerType", "Json");
 
-            if (_context != null)
-                return JsonSerializer.Deserialize(data, objectType, _context);
-            else
-                return JsonSerializer.Deserialize(data, objectType, _options);
+            return _context != null
+                ? JsonSerializer.Deserialize(data, objectType, _context)
+                : JsonSerializer.Deserialize(data, objectType, _options);
         }
     }
 }

--- a/src/Arc4u.Standard.Serializer.Protobuf/RuntimeTypeModelUpdater.cs
+++ b/src/Arc4u.Standard.Serializer.Protobuf/RuntimeTypeModelUpdater.cs
@@ -288,12 +288,12 @@ namespace Arc4u.Serializer.ProtoBuf
 
         private static Type GetMemberType(MemberInfo memberInfo)
         {
-            if (memberInfo is PropertyInfo propertyInfo)
-                return propertyInfo.PropertyType;
-            else if (memberInfo is FieldInfo fieldInfo)
-                return fieldInfo.FieldType;
-            else
-                throw new ArgumentException($"Unknown MemberInfo type {memberInfo?.GetType().Name}", nameof(memberInfo));
+            return memberInfo switch
+            {
+                PropertyInfo propertyInfo => propertyInfo.PropertyType,
+                FieldInfo fieldInfo => fieldInfo.FieldType,
+                _ => throw new ArgumentException($"Unknown MemberInfo type {memberInfo?.GetType().Name}", nameof(memberInfo))
+            };
         }
 
 

--- a/src/Arc4u.Standard.Serializer.Protobuf/TypeReconstructor.cs
+++ b/src/Arc4u.Standard.Serializer.Protobuf/TypeReconstructor.cs
@@ -48,8 +48,8 @@ namespace Arc4u.Serializer.ProtoBuf
 
             if (throwOnError)
                 throw new Exception($"The type \"{assemblyQualifiedName}\" cannot be found in referenced assemblies.");
-            else
-                return null;
+
+            return null;
         }
 
         private static readonly Regex _nameDecompositionRegex = new Regex(@"^(?<name>\w+(\.\w+)*)`(?<count>\d)\[(?<subtypes>\[.*\])\](, (?<assembly>\w+(\.\w+)*)[\w\s,=\.]+)$?", RegexOptions.Singleline | RegexOptions.ExplicitCapture);

--- a/src/Arc4u.Standard.Serializer.ProtobufV2/RuntimeTypeModelUpdater.cs
+++ b/src/Arc4u.Standard.Serializer.ProtobufV2/RuntimeTypeModelUpdater.cs
@@ -275,12 +275,12 @@ namespace Arc4u.Serializer.ProtoBuf
 
         private static Type GetMemberType(MemberInfo memberInfo)
         {
-            if (memberInfo is PropertyInfo propertyInfo)
-                return propertyInfo.PropertyType;
-            else if (memberInfo is FieldInfo fieldInfo)
-                return fieldInfo.FieldType;
-            else
-                throw new ArgumentException($"Unknown MemberInfo type {memberInfo?.GetType().Name}", nameof(memberInfo));
+            return memberInfo switch
+            {
+                PropertyInfo propertyInfo => propertyInfo.PropertyType,
+                FieldInfo fieldInfo => fieldInfo.FieldType,
+                _ => throw new ArgumentException($"Unknown MemberInfo type {memberInfo?.GetType().Name}", nameof(memberInfo))
+            };
         }
 
 

--- a/src/Arc4u.Standard.Serializer.ProtobufV2/TypeReconstructor.cs
+++ b/src/Arc4u.Standard.Serializer.ProtobufV2/TypeReconstructor.cs
@@ -48,8 +48,8 @@ namespace Arc4u.Serializer.ProtoBuf
 
             if (throwOnError)
                 throw new Exception($"The type \"{assemblyQualifiedName}\" cannot be found in referenced assemblies.");
-            else
-                return null;
+
+            return null;
         }
 
         private static readonly Regex _nameDecompositionRegex = new Regex(@"^(?<name>\w+(\.\w+)*)`(?<count>\d)\[(?<subtypes>\[.*\])\](, (?<assembly>\w+(\.\w+)*)[\w\s,=\.]+)$?", RegexOptions.Singleline | RegexOptions.ExplicitCapture);

--- a/src/Arc4u.Standard.Threading/AsynSemaphore.cs
+++ b/src/Arc4u.Standard.Threading/AsynSemaphore.cs
@@ -21,12 +21,10 @@ namespace Arc4u.Threading
                     --m_currentCount;
                     return s_completed;
                 }
-                else
-                {
-                    var waiter = new TaskCompletionSource<bool>();
-                    m_waiters.Enqueue(waiter);
-                    return waiter.Task;
-                }
+
+                var waiter = new TaskCompletionSource<bool>();
+                m_waiters.Enqueue(waiter);
+                return waiter.Task;
             }
         }
         public void Release()

--- a/src/Arc4u.Standard/Bound!1.cs
+++ b/src/Arc4u.Standard/Bound!1.cs
@@ -19,8 +19,8 @@ namespace Arc4u
 
         /// <summary>
         /// Gets the bound type.
-        /// </summary>        
-        /// <remarks>The set operation is not private to let the Silverlight runtime 
+        /// </summary>
+        /// <remarks>The set operation is not private to let the Silverlight runtime
         /// accessing the property during serializing/deserializing operations.</remarks>
         [DataMember(EmitDefaultValue = false)]
         public BoundType Type { get; internal set; }
@@ -28,15 +28,15 @@ namespace Arc4u
         /// <summary>
         /// Gets the bound direction.
         /// </summary>
-        /// <remarks>The set operation is not private to let the Silverlight runtime 
+        /// <remarks>The set operation is not private to let the Silverlight runtime
         /// accessing the property during serializing/deserializing operations.</remarks>
         [DataMember(EmitDefaultValue = false)]
         public BoundDirection Direction { get; internal set; }
 
         /// <summary>
         /// Gets the bound value.
-        /// </summary>        
-        /// <remarks>The set operation is not private to let the Silverlight runtime 
+        /// </summary>
+        /// <remarks>The set operation is not private to let the Silverlight runtime
         /// accessing the property during serializing/deserializing operations.</remarks>
         [DataMember(EmitDefaultValue = false)]
         public T Value { get; internal set; }
@@ -165,7 +165,7 @@ namespace Arc4u
         }
 
         /// <summary>
-        /// Returns the hash code for this instance. 
+        /// Returns the hash code for this instance.
         /// </summary>
         /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode()
@@ -185,7 +185,7 @@ namespace Arc4u
         /// Returns a value indicating whether this instance is equal to a specified object.
         /// </summary>
         /// <param name="obj">An object to compare to this instance.</param>
-        /// <returns>        
+        /// <returns>
         ///     <b>true</b> if this instance equals the <paramref name="obj"/>; otherwise, <b>false</b>.
         /// </returns>
         public override bool Equals(object obj)
@@ -237,11 +237,11 @@ namespace Arc4u
         /// <item>
         ///     <term>Zero</term>
         ///     <description>This instance is equal to the <paramref name="other"/>.</description>
-        /// </item>        
+        /// </item>
         /// <item>
         ///     <term>Greater than zero</term>
         ///     <description>This instance is greater than the <paramref name="other"/>.</description>
-        /// </item>        
+        /// </item>
         ///</list>
         /// </returns>
         /// <exception cref="ArgumentNullException"><paramref name="other"/> is null.</exception>
@@ -258,20 +258,16 @@ namespace Arc4u
             //consider value comparaison
             if (vCompare != 0)
                 return vCompare;
-            else
-            {
-                //perform type comparaison
-                var tCompare = Type.CompareTo(other.Type);
-                if (tCompare != 0)
-                    return tCompare;
-                else
-                {
-                    //perform direction comparaison
-                    return (Type == BoundType.Upper)
-                        ? Direction.CompareTo(other.Direction)
-                        : other.Direction.CompareTo(Direction);
-                }
-            }
+
+            //perform type comparaison
+            var tCompare = Type.CompareTo(other.Type);
+            if (tCompare != 0)
+                return tCompare;
+
+            //perform direction comparaison
+            return (Type == BoundType.Upper)
+                ? Direction.CompareTo(other.Direction)
+                : other.Direction.CompareTo(Direction);
         }
 
         internal int UnionCompareTo(Bound<T> other)

--- a/src/Arc4u.Standard/FlagsEnum.cs
+++ b/src/Arc4u.Standard/FlagsEnum.cs
@@ -39,7 +39,7 @@ namespace Arc4u
         /// </summary>
         /// <typeparam name="TEnum">An enumeration type.</typeparam>
         /// <param name="power">The raising power of two.</param>
-        /// <param name="result">When this methods returns, contains the matching value of <typeparamref name="TEnum"/>. This parameter is passed uninitialized.</param>        
+        /// <param name="result">When this methods returns, contains the matching value of <typeparamref name="TEnum"/>. This parameter is passed uninitialized.</param>
         /// <returns><b>true</b> if a matching value of <typeparamref name="TEnum"/> is found; otherwise, <b>false</b>.</returns>
         public static bool TryPowerOfTwo<TEnum>(object power, out TEnum result)
             where TEnum : struct
@@ -74,19 +74,19 @@ namespace Arc4u
 
             if (underlyingType == typeof(sbyte))
                 return Convert.ToSByte(value);
-            else if (underlyingType == typeof(short))
+            if (underlyingType == typeof(short))
                 return Convert.ToInt16(value);
-            else if (underlyingType == typeof(int))
+            if (underlyingType == typeof(int))
                 return Convert.ToInt32(value);
-            else if (underlyingType == typeof(long))
+            if (underlyingType == typeof(long))
                 return Convert.ToInt64(value);
-            else if (underlyingType == typeof(byte))
+            if (underlyingType == typeof(byte))
                 return Convert.ToByte(value);
-            else if (underlyingType == typeof(ushort))
+            if (underlyingType == typeof(ushort))
                 return Convert.ToUInt16(value);
-            else if (underlyingType == typeof(uint))
+            if (underlyingType == typeof(uint))
                 return Convert.ToUInt32(value);
-            else if (underlyingType == typeof(ulong))
+            if (underlyingType == typeof(ulong))
                 return Convert.ToUInt64(value);
 
             throw new NotSupportedException("Underlying type of provided type is not supported.");
@@ -94,7 +94,7 @@ namespace Arc4u
 
         /// <summary>
         /// Gets the power of two exponent from the specified <paramref name="value"/>.
-        /// </summary>       
+        /// </summary>
         /// <param name="value">A value.</param>
         /// <returns>The power of two exponent from the specified <paramref name="value"/>.</returns>
         /// <exception cref="ArgumentException"><paramref name="value"/> is not a power of two exponent.</exception>
@@ -109,7 +109,7 @@ namespace Arc4u
 
         /// <summary>
         /// Tries to get the power of two exponent from the specified <paramref name="value"/>.
-        /// </summary>        
+        /// </summary>
         /// <param name="value">A value.</param>
         /// <param name="result">When this methods returns, contains the power of two exponent from the specified <paramref name="value"/>. This parameter is passed uninitialized.</param>
         /// <returns><b>true</b> if the <paramref name="value"/> parameter is a power of two exponent; otherwise, <b>false</b>.</returns>
@@ -240,7 +240,7 @@ namespace Arc4u
 
             var modulo = FlagValues<TEnum>(type).Count();
             //for each flag value consider continuity with the ones following cyclically (modulo)
-            //for example Sunday|Monday|Tuesday|Friday|Saturday is continuous 
+            //for example Sunday|Monday|Tuesday|Friday|Saturday is continuous
             //when considering Friday with the flag values following: Saturday, Sunday, Monday, Tuesday
             for (int i = 0; i < array.Length; i++)
             {

--- a/src/Arc4u.Standard/Interval.cs
+++ b/src/Arc4u.Standard/Interval.cs
@@ -67,15 +67,15 @@ namespace Arc4u
         /// <typeparam name="T">The value type of the intervals.</typeparam>
         /// <returns>An <see cref="Interval&lt;T&gt;"/> containing no element.</returns>
         /// <remarks>
-        /// An empty <see cref="Interval&lt;T&gt;"/> is composed of one element 
-        /// (usually <c>default(T)</c> but not exclusively) 
+        /// An empty <see cref="Interval&lt;T&gt;"/> is composed of one element
+        /// (usually <c>default(T)</c> but not exclusively)
         /// with <see cref="BoundDirection.Opened"/> boundaries.
-        /// Except when <typeparamref name="T"/> represents a reference type, 
+        /// Except when <typeparamref name="T"/> represents a reference type,
         /// the default empty interval is composed of <see cref="BoundDirection.Closed"/> boundaries.
-        /// It enables the distinction between the default <see cref="Empty"/> interval and 
+        /// It enables the distinction between the default <see cref="Empty"/> interval and
         /// the <see cref="Universe"/> interval.
         /// </remarks>
-        /// <seealso cref="Interval&lt;T&gt;.IsEmpty"/>        
+        /// <seealso cref="Interval&lt;T&gt;.IsEmpty"/>
         /// <seealso href="http://en.wikipedia.org/wiki/Empty_set">Empty Set (set theory)</seealso>
         public static Interval<T> Empty<T>()
         {
@@ -165,13 +165,11 @@ namespace Arc4u
                     && Bound.IsInfinity(lowerBound.Value)
                     && lowerBound.Direction != upperBound.Direction)
                     return false;
-                else
-                    return (lowerBound.Direction == BoundDirection.Closed && Comparer<T>.Default.Compare(lowerBound.Value, value) == 0) || (upperBound.Direction == BoundDirection.Closed && Comparer<T>.Default.Compare(upperBound.Value, value) == 0);
+
+                return (lowerBound.Direction == BoundDirection.Closed && Comparer<T>.Default.Compare(lowerBound.Value, value) == 0) || (upperBound.Direction == BoundDirection.Closed && Comparer<T>.Default.Compare(upperBound.Value, value) == 0);
             }
-            else
-            {
-                return lowerBound.Contains(value) && upperBound.Contains(value);
-            }
+
+            return lowerBound.Contains(value) && upperBound.Contains(value);
         }
 
         #region Complement
@@ -363,8 +361,8 @@ namespace Arc4u
         /// <typeparam name="T">The value type of the intervals.</typeparam>
         /// <param name="a">The first interval.</param>
         /// <param name="b">The second interval.</param>
-        /// <param name="intersection">When this method returns, contains the <see cref="Interval&lt;T&gt;"/> 
-        /// that contains all elements of <paramref name="a"/> that also belong to <paramref name="b"/>; 
+        /// <param name="intersection">When this method returns, contains the <see cref="Interval&lt;T&gt;"/>
+        /// that contains all elements of <paramref name="a"/> that also belong to <paramref name="b"/>;
         /// otherwise, an empty interval.</param>
         /// <returns><b>true</b> if the intersection is not empty; otherwise, <b>false</b>.</returns>
         public static bool TryIntersectionOf<T>(Interval<T> a, Interval<T> b, out Interval<T> intersection)
@@ -396,8 +394,8 @@ namespace Arc4u
         /// <typeparam name="T">The value type of the intervals.</typeparam>
         /// <param name="a">The first interval.</param>
         /// <param name="b">The second interval.</param>
-        /// <returns>An <see cref="Interval&lt;T&gt;"/> that contains all elements of <paramref name="a"/> 
-        /// that also belong to <paramref name="b"/> (or equivalently, all elements of <paramref name="b"/> 
+        /// <returns>An <see cref="Interval&lt;T&gt;"/> that contains all elements of <paramref name="a"/>
+        /// that also belong to <paramref name="b"/> (or equivalently, all elements of <paramref name="b"/>
         /// that also belong to <paramref name="a"/>), but no other elements.</returns>
         /// <seealso href="http://en.wikipedia.org/wiki/Intersection_(set_theory)">Intersection (set theory)</seealso>
         private static Interval<T> IntersectionOf<T>(Interval<T> a, Interval<T> b)
@@ -472,7 +470,7 @@ namespace Arc4u
             }
 
             //        a
-            //  -------------            
+            //  -------------
             //    b
             //---------
             else if (object.Equals(lowestBound, b.LowerBound)
@@ -707,7 +705,7 @@ namespace Arc4u
             }
 
             //        a
-            //  -------------            
+            //  -------------
             //    b
             //---------
             else if (object.Equals(lowestBound, b.LowerBound) &&

--- a/src/Arc4u.Standard/Security/Cryptography/x509Certificate2.cs
+++ b/src/Arc4u.Standard/Security/Cryptography/x509Certificate2.cs
@@ -40,28 +40,26 @@ public static class Certificate
         {
             throw new AppException("No CertificateName key found in the settings provided.");
         }
-        else
+
+        var certificateInfo = new CertificateInfo
         {
-            var certificateInfo = new CertificateInfo
-            {
-                Name = certificateName
-            };
+            Name = certificateName
+        };
 
-            if (Enum.TryParse(findType, out X509FindType x509FindType))
-            {
-                certificateInfo.FindType = x509FindType;
-            }
-            if (Enum.TryParse(storeLocation, out StoreLocation storeLocation_))
-            {
-                certificateInfo.Location = storeLocation_;
-            }
-            if (Enum.TryParse(storeName, out StoreName storeName_))
-            {
-                certificateInfo.StoreName = storeName_;
-            }
-
-            return FindCertificate(certificateInfo);
+        if (Enum.TryParse(findType, out X509FindType x509FindType))
+        {
+            certificateInfo.FindType = x509FindType;
         }
+        if (Enum.TryParse(storeLocation, out StoreLocation storeLocation_))
+        {
+            certificateInfo.Location = storeLocation_;
+        }
+        if (Enum.TryParse(storeName, out StoreName storeName_))
+        {
+            certificateInfo.StoreName = storeName_;
+        }
+
+        return FindCertificate(certificateInfo);
     }
 
     [Obsolete("Use the X509CertificateLoader instead.")]

--- a/src/Arc4u.Standard/Utils/Enum.cs
+++ b/src/Arc4u.Standard/Utils/Enum.cs
@@ -310,10 +310,8 @@ namespace Arc4u.Utils
             {
                 return result.Value;
             }
-            else
-            {
-                throw e;
-            }
+
+            throw e;
         }
 
         public static T? TryParse<T>(object value)


### PR DESCRIPTION
This pull request includes the following changes:

1. Refactored multiple methods across various classes to remove the use of the else keyword. This is in line with the principles of clean code that recommend early return to improve readability and reduce complexity.

The else keyword often leads to increased indentation and nested conditionals, both of which can make the code harder to read and understand. By using early returns and careful control flow management, we can make the code cleaner and more efficient.

Please review the changes and let me know if any modifications are required. These changes should not affect the functionality of the code, but should make it easier to read and maintain in the future.