### PR TITLE
removed the line options.Server = c.Server

### DIFF
--- a/src/Arc4u.Standard.MongoDB/Configuration/MongoDbConnection.cs
+++ b/src/Arc4u.Standard.MongoDB/Configuration/MongoDbConnection.cs
@@ -45,7 +45,6 @@ namespace Microsoft.Extensions.DependencyInjection
                 options.RetryReads = c.RetryReads;
                 options.RetryWrites = c.RetryWrites;
                 options.Scheme = c.Scheme;
-                options.Server = c.Server;
                 options.Servers = c.Servers;
                 options.ServerSelectionTimeout = c.ServerSelectionTimeout;
                 options.SocketTimeout = c.SocketTimeout;


### PR DESCRIPTION
This is a fix for #56 HA mongo db connectionstring causes crash in Arc4u.MongoDB