### PR TITLE
Fix badge display issue in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Arc4u
 
-SonarCloud info </br>
+SonarCloud info
 
-> [![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=GFlisch_Arc4u&metric=vulnerabilities)](https://sonarcloud.io/summary/new_code?id=GFlisch_Arc4u) </br>
-> [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=GFlisch_Arc4u&metric=bugs)](https://sonarcloud.io/summary/new_code?id=GFlisch_Arc4u) </br>
->[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=GFlisch_Arc4u&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=GFlisch_Arc4u)
+[![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=GFlisch_Arc4u&metric=vulnerabilities)](https://sonarcloud.io/summary/new_code?id=GFlisch_Arc4u)
 
+[![Bugs](https://sonarcloud.io/api/project_badges/measure?project=GFlisch_Arc4u&metric=bugs)](https://sonarcloud.io/summary/new_code?id=GFlisch_Arc4u)
+
+[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=GFlisch_Arc4u&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=GFlisch_Arc4u)
 
 ## Arc4u is a framework to ease the development of applications. 
   


### PR DESCRIPTION
Minor PR  fixing an issue where badges in the README were not rendering due to the  the `>` character, which is used in Markdown for blockquotes. By removing these characters, the badges display correctly.

Before and After
Before:
![image](https://github.com/GFlisch/Arc4u/assets/6811304/f9b4ec70-cdf5-4e13-81b5-94d03d3977a5)

After:
![image](https://github.com/GFlisch/Arc4u/assets/6811304/13546dde-992c-4b19-b9b7-776b6336b5fd)