### PR TITLE
Avoid [Simple]KeyValueSettings to crash on non-string configuration properties - Part 1

### DIFF
--- a/src/Arc4u.Standard.Configuration/Configuration/ConfigurationSettingsExtension.cs
+++ b/src/Arc4u.Standard.Configuration/Configuration/ConfigurationSettingsExtension.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -9,7 +9,7 @@ namespace Arc4u.Configuration;
 public static class ConfigurationSettingsExtension
 {
     /// <summary>
-    /// Register a key/value collection with IOption model.
+    /// Register a key/value collection with IOption model, only taking the properties that map to strings.
     /// <param name="services">The service collection <see cref="IServiceCollection"/></param>
     /// <param name="name">The name to get the back the DIctionary.</param>
     /// <param name="configuration"><see cref="IConfiguration"/> to read the settings.</param>
@@ -47,13 +47,13 @@ public static class ConfigurationSettingsExtension
         }
 
         // Get a `Dictionary<string, string>` from the `section`.
-        var dic = section.Get<Dictionary<string, string>>() ?? throw new ConfigurationException($"Section {sectionName} is not a Dictionary<string,string>.");
+        var dic = section.GetChildren()?.ToDictionary(x => x.Key, x => x.Value!) ?? throw new ArgumentException($"Section {sectionName} doesn't contain a usable string dictionary", nameof(sectionName));
 
         // Define a local method `options` that takes a `Dictionary<string, string>` parameter `o` and adds each key-value pair
         // from the retrieved dictionary `dic` to it.
         void options(SimpleKeyValueSettings o)
         {
-            foreach (var kv in dic!)
+            foreach (var kv in dic)
             {
                 o.Add(kv.Key, kv.Value);
             }

--- a/src/Arc4u.Standard.Configuration/Configuration/KeyValueSettings.cs
+++ b/src/Arc4u.Standard.Configuration/Configuration/KeyValueSettings.cs
@@ -1,18 +1,19 @@
-﻿using Microsoft.Extensions.Configuration;
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Configuration;
 
 namespace Arc4u.Configuration
 {
     public abstract class KeyValueSettings : IKeyValueSettings
     {
+        private readonly Dictionary<string, string> _properties;
+
         public KeyValueSettings(string sectionName, IConfiguration configuration)
         {
-            Properties = configuration.GetSection(sectionName).Get<Dictionary<String, String>>();
+            _properties = configuration.GetSection(sectionName)?.GetChildren()?.ToDictionary(x => x.Key, x => x.Value!) ?? throw new ArgumentException($"Section {sectionName} does not exist or doesn't contain a usable value", nameof(sectionName));
         }
 
-        private Dictionary<String, String> Properties { get; }
-
-        public IReadOnlyDictionary<string, string> Values => Properties;
+        public IReadOnlyDictionary<string, string> Values => _properties;
     }
 }


### PR DESCRIPTION
When configurations are mapped to `[Simple]KeyValueProperties`, like this:

~~~csharp
services.ConfigureSettings("OAuth2", builder.Configuration, "Blazor.OAuth2.Client.Settings");
services.ConfigureSettings("AppSettings", builder.Configuration, "AppSettings");
~~~

... these mappings assume that all the property types of the corresponding configuration section to be `string`.

This is an issue everwherre `ConfigureSettings` is used, in both front- and backends.

This means that we are not allowed to use these sections for more complex types. This is problematic for example in the first statement where `Blazor.OAuth2.Client.Settings` is also used to bind to the authentication settings and can contain arrays (for scopes). This needs to be treated as a special case, because the section is interpreted as containing all strings.

It's also needlessly limiting with `AppSettings`. Even if you can access your property directly (using Configuration["AppSettings:MyProperty"], the call to `ConfigureSettings` will fail at startup.

Part 1 to solve this problem is to make sure that the call to `ConfigureSettings` doesn't crash when non-string properties are present. This is what this pull request is all about.

Part 2 is a future pull request that will make [Simple]KeyValueSettings obsolete: this is just a section alias, and we don't need the type (and its corresponding `IKeyValueSettings` at all.

