### PR TITLE
RefreshTokenProvider doesn't handle access_token refresh properly except for the first time.Feature/refresh token provider

### DIFF
--- a/src/Arc4u.Standard.Configuration/Configuration/ConfigurationSettingsExtension.cs
+++ b/src/Arc4u.Standard.Configuration/Configuration/ConfigurationSettingsExtension.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -9,7 +9,7 @@ namespace Arc4u.Configuration;
 public static class ConfigurationSettingsExtension
 {
     /// <summary>
-    /// Register a key/value collection with IOption model.
+    /// Register a key/value collection with IOption model, only taking the properties that map to strings.
     /// <param name="services">The service collection <see cref="IServiceCollection"/></param>
     /// <param name="name">The name to get the back the DIctionary.</param>
     /// <param name="configuration"><see cref="IConfiguration"/> to read the settings.</param>
@@ -47,13 +47,13 @@ public static class ConfigurationSettingsExtension
         }
 
         // Get a `Dictionary<string, string>` from the `section`.
-        var dic = section.Get<Dictionary<string, string>>() ?? throw new ConfigurationException($"Section {sectionName} is not a Dictionary<string,string>.");
+        var dic = section.GetChildren()?.ToDictionary(x => x.Key, x => x.Value!) ?? throw new ArgumentException($"Section {sectionName} doesn't contain a usable string dictionary", nameof(sectionName));
 
         // Define a local method `options` that takes a `Dictionary<string, string>` parameter `o` and adds each key-value pair
         // from the retrieved dictionary `dic` to it.
         void options(SimpleKeyValueSettings o)
         {
-            foreach (var kv in dic!)
+            foreach (var kv in dic)
             {
                 o.Add(kv.Key, kv.Value);
             }

--- a/src/Arc4u.Standard.Configuration/Configuration/KeyValueSettings.cs
+++ b/src/Arc4u.Standard.Configuration/Configuration/KeyValueSettings.cs
@@ -1,18 +1,19 @@
-﻿using Microsoft.Extensions.Configuration;
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Configuration;
 
 namespace Arc4u.Configuration
 {
     public abstract class KeyValueSettings : IKeyValueSettings
     {
+        private readonly Dictionary<string, string> _properties;
+
         public KeyValueSettings(string sectionName, IConfiguration configuration)
         {
-            Properties = configuration.GetSection(sectionName).Get<Dictionary<String, String>>();
+            _properties = configuration.GetSection(sectionName)?.GetChildren()?.ToDictionary(x => x.Key, x => x.Value!) ?? throw new ArgumentException($"Section {sectionName} does not exist or doesn't contain a usable value", nameof(sectionName));
         }
 
-        private Dictionary<String, String> Properties { get; }
-
-        public IReadOnlyDictionary<string, string> Values => Properties;
+        public IReadOnlyDictionary<string, string> Values => _properties;
     }
 }


### PR DESCRIPTION
When an access token is expired, it's up to [`StandardCookieEvents`](https://github.com/GFlisch/Arc4u/blob/master/src/Arc4u.Standard.OAuth2.AspNetCore.Authentication/Events/StandardCookieEvents.cs) to handle the refresh.

Ultimately, this will end up calling [`ITokenRefreshProvider`](https://github.com/GFlisch/Arc4u/blob/master/src/Arc4u.Standard.OAuth2.AspNetCore.Authentication/TokenProviders/ITokenRefresh.cs) and therefore [`RefreshTokenProvider`](https://github.com/GFlisch/Arc4u/blob/master/src/Arc4u.Standard.OAuth2.AspNetCore.Authentication/TokenProviders/RefreshTokenProvider.cs), the `RefreshTokenProvider` assumes that the return value will always contain a refresh_token. On ADFS 2019, this will never contain a refresh token, only an access_token. 

So the *next* time the `RefreshTokenProvider` is called, it will fail because the refresh token will be null.

The easy solution is to check if a refresh token is present, and only replace the `TokenRefreshInfo.TokenRefresh` if so, while being smart about the expiration date.