### PR TITLE
Rewrite certificate extractor to avoid using the obsolete WebRequest.

### DIFF
--- a/src/Arc4u.Standard.Configuration/Configuration/ConfigurationSettingsExtension.cs
+++ b/src/Arc4u.Standard.Configuration/Configuration/ConfigurationSettingsExtension.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -9,7 +9,7 @@ namespace Arc4u.Configuration;
 public static class ConfigurationSettingsExtension
 {
     /// <summary>
-    /// Register a key/value collection with IOption model.
+    /// Register a key/value collection with IOption model, only taking the properties that map to strings.
     /// <param name="services">The service collection <see cref="IServiceCollection"/></param>
     /// <param name="name">The name to get the back the DIctionary.</param>
     /// <param name="configuration"><see cref="IConfiguration"/> to read the settings.</param>
@@ -47,13 +47,13 @@ public static class ConfigurationSettingsExtension
         }
 
         // Get a `Dictionary<string, string>` from the `section`.
-        var dic = section.Get<Dictionary<string, string>>() ?? throw new ConfigurationException($"Section {sectionName} is not a Dictionary<string,string>.");
+        var dic = section.GetChildren()?.ToDictionary(x => x.Key, x => x.Value!) ?? throw new ArgumentException($"Section {sectionName} doesn't contain a usable string dictionary", nameof(sectionName));
 
         // Define a local method `options` that takes a `Dictionary<string, string>` parameter `o` and adds each key-value pair
         // from the retrieved dictionary `dic` to it.
         void options(SimpleKeyValueSettings o)
         {
-            foreach (var kv in dic!)
+            foreach (var kv in dic)
             {
                 o.Add(kv.Key, kv.Value);
             }

--- a/src/Arc4u.Standard.Configuration/Configuration/KeyValueSettings.cs
+++ b/src/Arc4u.Standard.Configuration/Configuration/KeyValueSettings.cs
@@ -1,18 +1,19 @@
-﻿using Microsoft.Extensions.Configuration;
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Configuration;
 
 namespace Arc4u.Configuration
 {
     public abstract class KeyValueSettings : IKeyValueSettings
     {
+        private readonly Dictionary<string, string> _properties;
+
         public KeyValueSettings(string sectionName, IConfiguration configuration)
         {
-            Properties = configuration.GetSection(sectionName).Get<Dictionary<String, String>>();
+            _properties = configuration.GetSection(sectionName)?.GetChildren()?.ToDictionary(x => x.Key, x => x.Value!) ?? throw new ArgumentException($"Section {sectionName} does not exist or doesn't contain a usable value", nameof(sectionName));
         }
 
-        private Dictionary<String, String> Properties { get; }
-
-        public IReadOnlyDictionary<string, string> Values => Properties;
+        public IReadOnlyDictionary<string, string> Values => _properties;
     }
 }

--- a/src/Arc4u.Standard.gRPC/ChannelCertificate/IRootCertificateExtractor.cs
+++ b/src/Arc4u.Standard.gRPC/ChannelCertificate/IRootCertificateExtractor.cs
@@ -1,12 +1,10 @@
-﻿using System;
+#nullable enable
+using System;
 using System.Security.Cryptography.X509Certificates;
 
-namespace Arc4u.gRPC.ChannelCertificate
-{
-    public interface IRootCertificateExtractor
-    {
-        X509Certificate2 Certificate { get; }
+namespace Arc4u.gRPC.ChannelCertificate;
 
-        bool FetchCertificateFor(Uri rootUrl);
-    }
+public interface IRootCertificateExtractor
+{
+    X509Certificate2? FetchCertificateFor(Uri rootUrl);
 }

--- a/src/Arc4u.Standard.gRPC/ChannelCertificate/RootCertificateExtractor.cs
+++ b/src/Arc4u.Standard.gRPC/ChannelCertificate/RootCertificateExtractor.cs
@@ -1,58 +1,91 @@
-﻿using Arc4u.Dependency.Attribute;
-using Arc4u.Diagnostics;
-using Microsoft.Extensions.Logging;
+#nullable enable
 using System;
-using System.Net;
+using System.Net.Http;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
+using Arc4u.Dependency.Attribute;
+using Arc4u.Diagnostics;
+using Microsoft.Extensions.Logging;
 
-namespace Arc4u.gRPC.ChannelCertificate
+namespace Arc4u.gRPC.ChannelCertificate;
+
+[Export(typeof(IRootCertificateExtractor))]
+public class RootCertificateExtractor : IRootCertificateExtractor, IDisposable
 {
-    [Export(typeof(IRootCertificateExtractor))]
-    public class RootCertificateExtractor : IRootCertificateExtractor
+    public RootCertificateExtractor(ILogger<RootCertificateExtractor> logger)
     {
-        public RootCertificateExtractor(ILogger<RootCertificateExtractor> logger)
+        _logger = logger;
+        _httpClient = new HttpClient(new HttpClientHandler { AllowAutoRedirect = false, ServerCertificateCustomValidationCallback = ServerCertificateValidationCallback });
+    }
+
+    private readonly ILogger<RootCertificateExtractor> _logger;
+    private readonly HttpClient _httpClient;
+#if NETSTANDARD
+    private static readonly string _key = nameof(CertificateHolder);
+#else
+    private static readonly HttpRequestOptionsKey<CertificateHolder> _key = new(nameof(CertificateHolder));
+#endif
+
+    private sealed class CertificateHolder
+    {
+        public X509Certificate2? Certificate { get; set; }
+    }
+
+    public X509Certificate2? FetchCertificateFor(Uri rootUrl)
+    {
+        if (!rootUrl.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
         {
-            _logger = logger;
+            throw new ArgumentException("Secure https protocol is expected.");
         }
 
-        readonly ILogger<RootCertificateExtractor> _logger;
-
-        public X509Certificate2 Certificate { get; private set; }
-
-        public bool FetchCertificateFor(Uri rootUrl)
+        try
         {
-            Certificate = null;
-
-            if (!rootUrl.Scheme.Equals("https", StringComparison.InvariantCultureIgnoreCase))
-                throw new ArgumentException("Secure https protocol is expected.");
-
-            try
-            {
-                var request = (HttpWebRequest)WebRequest.Create(rootUrl);
-                request.AllowAutoRedirect = false;
-                request.ServerCertificateValidationCallback = ServerCertificateValidationCallback;
-
-                HttpWebResponse response = (HttpWebResponse)request.GetResponse();
-                response.Close();
-            }
-            catch (Exception ex)
-            {
-                _logger.Technical().LogException(ex);
-
-                return false;
-            }
-
-            return true;
+            var certificateHolder = new CertificateHolder();
+            using var request = new HttpRequestMessage(HttpMethod.Get, rootUrl);
+#if NETSTANDARD
+            request.Properties[_key] = certificateHolder;
+            using var response = _httpClient.SendAsync(request).GetAwaiter().GetResult();
+#else
+            request.Options.Set(_key, certificateHolder);
+            using var response = _httpClient.Send(request);
+#endif
+            // Note that this will oonly work once: next calls will not trigger ServerCertificateCustomValidationCallback because _httpClient will cache the response.
+            return certificateHolder.Certificate;
         }
-
-        private bool ServerCertificateValidationCallback(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)
+        catch (Exception ex)
         {
-            Certificate = new X509Certificate2(certificate);
+            _logger.Technical().LogException(ex);
+            return null;
+        }
+    }
 
+    private bool ServerCertificateValidationCallback(HttpRequestMessage sender, X509Certificate? certificate, X509Chain? chain, SslPolicyErrors sslPolicyErrors)
+    {
+        if (certificate is not null)
+        {
             _logger.Technical().System($"Certificate callback received with Subject = {certificate.Subject}.").Log();
-
-            return SslPolicyErrors.None == sslPolicyErrors;
+#if NETSTANDARD
+            if (sender.Properties.TryGetValue(_key, out var certificateHolder))
+            {
+                ((CertificateHolder)certificateHolder).Certificate = new X509Certificate2(certificate);
+            }
+#else
+            if (sender.Options.TryGetValue(_key, out var certificateHolder))
+            {
+                certificateHolder.Certificate = new X509Certificate2(certificate);
+            }
+#endif
         }
+        else
+        {
+            _logger.Technical().System($"Certificate callback received no certificate.").Log();
+        }
+
+        return sslPolicyErrors == SslPolicyErrors.None;
+    }
+
+    public void Dispose()
+    {
+        _httpClient.Dispose();
     }
 }

--- a/src/Arc4u.Standard.gRPC/ChannelCertificate/RootPemCertificates.cs
+++ b/src/Arc4u.Standard.gRPC/ChannelCertificate/RootPemCertificates.cs
@@ -1,100 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
 using Arc4u.Dependency.Attribute;
 using Arc4u.Diagnostics;
 using Microsoft.Extensions.Logging;
-using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Security.Cryptography.X509Certificates;
-using System.Text;
 
-namespace Arc4u.gRPC.ChannelCertificate
+namespace Arc4u.gRPC.ChannelCertificate;
+
+[Export, Shared]
+public class RootPemCertificates
 {
-    [Export, Shared]
-    public class RootPemCertificates
+    public RootPemCertificates(IRootCertificateExtractor certificateExtractor, ILogger<RootPemCertificates> logger)
     {
-        public RootPemCertificates(IRootCertificateExtractor certificateExtractor, ILogger<RootPemCertificates> logger)
-        {
-            _certificateExtractor = certificateExtractor;
-            _certificateExtractor = certificateExtractor;
+        _certificateExtractor = certificateExtractor;
+        _pemsCollections = new Dictionary<string, string>();
+        _logger = logger;
+    }
 
-            PemsCollections = new Dictionary<string, string>();
-            _logger = logger;
+    readonly IRootCertificateExtractor _certificateExtractor;
+    readonly ILogger<RootPemCertificates> _logger;
+    static readonly object _lock = new();
+
+    public IReadOnlyDictionary<string, string> Pems => _pemsCollections;
+
+    private readonly Dictionary<string, string> _pemsCollections;
+
+    public string GetPemFor(Uri rootUri)
+    {
+        if (rootUri is null)
+        {
+            throw new ArgumentNullException(nameof(rootUri));
         }
 
-        readonly IRootCertificateExtractor _certificateExtractor;
-        readonly ILogger<RootPemCertificates> _logger;
-        static readonly object _lock = new object();
-
-        public IReadOnlyDictionary<string, string> Pems { get => new ReadOnlyDictionary<string, string>(PemsCollections); }
-
-        private Dictionary<string, string> PemsCollections;
-
-        public string GetPemFor(Uri rootUri)
+        if (_pemsCollections.TryGetValue(rootUri.Host, out var pem))
         {
-            if (null == rootUri)
-                throw new ArgumentNullException(nameof(rootUri));
+            return pem;
+        }
 
-            if (PemsCollections.ContainsKey(rootUri.Host)) return PemsCollections[rootUri.Host];
+        try
+        {
+            var certificate = _certificateExtractor.FetchCertificateFor(rootUri);
 
-            try
+            if (certificate is null)
             {
-                lock (_lock)
-                {
-                    if (!_certificateExtractor.FetchCertificateFor(rootUri))
-                        throw new KeyNotFoundException(rootUri.ToString());
-
-                    if (null == _certificateExtractor.Certificate)
-                    {
-                        _logger.Technical().System($"Certificate was not retrieved from the uri.").Log();
-                        throw new KeyNotFoundException(rootUri.ToString());
-                    }
-
-                    _logger.Technical().System($"Certificate used is {_certificateExtractor.Certificate.Subject}.").Log();
-
-                    var pem = ExportToPem(_certificateExtractor.Certificate);
-
-                    if (string.IsNullOrWhiteSpace(pem))
-                    {
-                        _logger.Technical().System($"Pem extaction is empty.").Log();
-                        throw new KeyNotFoundException(rootUri.ToString());
-                    }
-
-                    PemsCollections.Add(rootUri.Host, pem);
-
-                    return pem;
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.Technical().Exception(ex).Log();
-
+                _logger.Technical().System($"Certificate was not retrieved from the uri.").Log();
                 throw new KeyNotFoundException(rootUri.ToString());
             }
 
+            _logger.Technical().System($"Certificate used is {certificate.Subject}.").Log();
+
+            pem = ExportToPem(certificate);
+
+            if (string.IsNullOrWhiteSpace(pem))
+            {
+                _logger.Technical().System($"Pem extaction is empty.").Log();
+                throw new KeyNotFoundException(rootUri.ToString());
+            }
+
+            lock (_lock)
+            {
+                _pemsCollections.Add(rootUri.Host, pem);
+            }
+
+            return pem;
         }
-
-
-        /// <summary>
-        /// Export a certificate to a PEM format string
-        /// </summary>
-        /// <param name="cert">The certificate to export</param>
-        /// <returns>A PEM encoded string</returns>
-        public static string ExportToPem(X509Certificate2 cert)
+        catch (Exception ex)
         {
-            StringBuilder builder = new StringBuilder();
+            _logger.Technical().Exception(ex).Log();
 
-            try
-            {
-                builder.AppendLine("-----BEGIN CERTIFICATE-----");
-                builder.AppendLine(Convert.ToBase64String(cert.Export(X509ContentType.Cert), Base64FormattingOptions.InsertLineBreaks));
-                builder.AppendLine("-----END CERTIFICATE-----");
-
-            }
-            catch (Exception)
-            {
-            }
-
-            return builder.ToString();
+            throw new KeyNotFoundException(rootUri.ToString());
         }
+    }
+
+    /// <summary>
+    /// Export a certificate to a PEM format string
+    /// </summary>
+    /// <param name="cert">The certificate to export</param>
+    /// <returns>A PEM encoded string</returns>
+    public static string ExportToPem(X509Certificate2 cert)
+    {
+        var builder = new StringBuilder();
+
+        try
+        {
+            builder.AppendLine("-----BEGIN CERTIFICATE-----");
+            builder.AppendLine(Convert.ToBase64String(cert.Export(X509ContentType.Cert), Base64FormattingOptions.InsertLineBreaks));
+            builder.AppendLine("-----END CERTIFICATE-----");
+
+        }
+        catch (Exception)
+        {
+        }
+
+        return builder.ToString();
     }
 }


### PR DESCRIPTION
Previous implementation used WebRequest (which is obsolete) and could not return the certificate in the same call.

The new implementation uses HttpClient and simplifies the interface.