### PR TITLE
Access an Activity Id independently of the existance of an application principal

### DIFF
--- a/src/Arc4u.Standard.OAuth.Msal/Token/JwtHttpHandler.cs
+++ b/src/Arc4u.Standard.OAuth.Msal/Token/JwtHttpHandler.cs
@@ -1,14 +1,14 @@
-using Arc4u.Dependency;
-using Arc4u.Diagnostics;
-using Arc4u.OAuth2.Token;
-using Arc4u.Security.Principal;
-using Microsoft.Extensions.Logging;
 using System;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
+using Arc4u.Dependency;
+using Arc4u.Diagnostics;
+using Arc4u.OAuth2.Token;
+using Arc4u.Security.Principal;
+using Microsoft.Extensions.Logging;
 
 namespace Arc4u.OAuth2.Msal.Token;
 
@@ -130,10 +130,10 @@ public class JwtHttpHandler : DelegatingHandler
             // Add ActivityId if founded!
             if (null != _applicationContext?.Principal)
             {
-                if (null != _applicationContext?.Principal?.ActivityID)
+                if (null != _applicationContext?.ActivityID)
                 {
-                    _logger.Technical().System($"Add the activity id to the request for tracing purpose: {_applicationContext.Principal.ActivityID}.").Log();
-                    request.Headers.Add("activityid", _applicationContext.Principal.ActivityID.ToString());
+                    _logger.Technical().System($"Add the activity id to the request for tracing purpose: {_applicationContext.ActivityID}.").Log();
+                    request.Headers.Add("activityid", _applicationContext.ActivityID);
                 }
 
                 _logger.Technical().System($"Add the current culture to the request: {_applicationContext.Principal.Profile?.CurrentCulture?.TwoLetterISOLanguageName}").Log();

--- a/src/Arc4u.Standard.OAuth2.AspNetCore/Filters/ManageExceptionsFilter.cs
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore/Filters/ManageExceptionsFilter.cs
@@ -30,10 +30,10 @@ public class ManageExceptionsFilter : IAsyncExceptionFilter
     public Task OnExceptionAsync(ExceptionContext context)
     {
         // If the activity id is not set, create one. This is the case for anonymous users.
-        var activityId = _application?.Principal?.ActivityID.ToString() ?? Activity.Current?.Id ?? Guid.NewGuid().ToString();
+        var activityId = _application?.ActivityID ?? Activity.Current?.Id ?? Guid.NewGuid().ToString();
 
         // First log the exception.
-        _logger.Technical().Exception(context.Exception).AddIf(_application?.Principal?.ActivityID is null, LoggingConstants.ActivityId, activityId).Log();
+        _logger.Technical().Exception(context.Exception).AddIf(_application?.ActivityID is null, LoggingConstants.ActivityId, activityId).Log();
 
         switch (context.Exception)
         {

--- a/src/Arc4u.Standard.OAuth2.AspNetCore/Middleware/AddContextToPrincipalMiddleware.cs
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore/Middleware/AddContextToPrincipalMiddleware.cs
@@ -40,9 +40,7 @@ public class AddContextToPrincipalMiddleware
                 context.Request.Headers.Add("traceparent", Activity.Current!.Id);
             }
 
-            principal.ActivityID = Activity.Current!.Id;
-
-            activity?.SetTag(LoggingConstants.ActivityId, principal.ActivityID);
+            activity?.SetTag(LoggingConstants.ActivityId, Activity.Current!.Id);
 
             // Check for a culture.
             var cultureHeader = context.Request?.Headers?.FirstOrDefault(h => h.Key.Equals("culture", StringComparison.InvariantCultureIgnoreCase));

--- a/src/Arc4u.Standard.OAuth2.AspNetCore/Security/AppServicePrincipalFactory.cs
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore/Security/AppServicePrincipalFactory.cs
@@ -76,15 +76,12 @@ public class AppServicePrincipalFactory : IAppPrincipalFactory
 
         if (principal is AppPrincipal appPrincipal)
         {
-            appPrincipal.ActivityID = Activity.Current?.Id ?? Guid.NewGuid().ToString();
-
-            activity?.SetTag(LoggingConstants.ActivityId, appPrincipal.ActivityID);
-
+            activity?.SetTag(LoggingConstants.ActivityId, Activity.Current?.Id ?? Guid.NewGuid().ToString());
             return appPrincipal;
         }
 
         throw new AppPrincipalException("No principal can be created.");
-        
+
     }
 
     /// <summary>

--- a/src/Arc4u.Standard.gRPC/Interceptors/AuthorizationInterceptor.cs
+++ b/src/Arc4u.Standard.gRPC/Interceptors/AuthorizationInterceptor.cs
@@ -1,3 +1,8 @@
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.Text.Json;
+using System.Threading.Tasks;
 using Arc4u.Diagnostics;
 using Arc4u.Security.Principal;
 using Google.Rpc;
@@ -5,11 +10,6 @@ using Grpc.Core;
 using Grpc.Core.Interceptors;
 using GrpcRichError;
 using Microsoft.Extensions.Logging;
-using System;
-using System.Diagnostics;
-using System.Globalization;
-using System.Text.Json;
-using System.Threading.Tasks;
 
 namespace Arc4u.gRPC.Interceptors
 {
@@ -99,10 +99,7 @@ namespace Arc4u.gRPC.Interceptors
 
         private void SetActivityIDIfExist(ServerCallContext _)
         {
-            if (null != _applicationContext.Principal)
-            {
-                _applicationContext.Principal.ActivityID = Activity.Current?.Id ?? Guid.NewGuid().ToString();
-            }
+            _applicationContext.ActivityID = Activity.Current?.Id ?? Guid.NewGuid().ToString();
         }
 
         public override async Task ServerStreamingServerHandler<TRequest, TResponse>(TRequest request, IServerStreamWriter<TResponse> responseStream, ServerCallContext context, ServerStreamingServerMethod<TRequest, TResponse> continuation)

--- a/src/Arc4u.Standard/Diagnostics/DefaultLoggingProperties.cs
+++ b/src/Arc4u.Standard/Diagnostics/DefaultLoggingProperties.cs
@@ -1,7 +1,7 @@
-﻿using Arc4u.Dependency.Attribute;
-using Arc4u.Security.Principal;
 using System;
 using System.Collections.Generic;
+using Arc4u.Dependency.Attribute;
+using Arc4u.Security.Principal;
 
 namespace Arc4u.Diagnostics
 {
@@ -23,7 +23,7 @@ namespace Arc4u.Diagnostics
                 {
                     return new Dictionary<string, object>
                         {
-                            { LoggingConstants.ActivityId, _applicationContext.Principal.ActivityID.ToString() },
+                            { LoggingConstants.ActivityId, _applicationContext.ActivityID },
                             { LoggingConstants.Identity, (null != _applicationContext.Principal?.Profile)
                                                                                             ? _applicationContext.Principal.Profile.Name
                                                                                             : null != _applicationContext.Principal?.Identity ? _applicationContext.Principal.Identity.Name : String.Empty }

--- a/src/Arc4u.Standard/Security/Principal/AppPrincipal.cs
+++ b/src/Arc4u.Standard/Security/Principal/AppPrincipal.cs
@@ -129,11 +129,6 @@ namespace Arc4u.Security.Principal
         /// <exclude/>
         public Authorization Authorization { get; }
 
-        /// <summary>
-        /// Gets or sets the activity ID.
-        /// </summary>
-        /// <value>The activity ID.</value>
-        public string ActivityID { get; set; } = string.Empty;
 
         // If user profile is 
         private UserProfile profile;

--- a/src/Arc4u.Standard/Security/Principal/ApplicationClaimsPrincipalSelectorContext.cs
+++ b/src/Arc4u.Standard/Security/Principal/ApplicationClaimsPrincipalSelectorContext.cs
@@ -1,6 +1,6 @@
-﻿using Arc4u.Dependency.Attribute;
 using System.Security.Claims;
 using System.Threading;
+using Arc4u.Dependency.Attribute;
 
 namespace Arc4u.Security.Principal
 {
@@ -9,6 +9,12 @@ namespace Arc4u.Security.Principal
     public class ApplicationClaimsPrincipalSelectorContext : IApplicationContext
     {
         public AppPrincipal Principal => ClaimsPrincipal.Current as AppPrincipal;
+
+        /// <summary>
+        /// Gets or sets the activity ID.
+        /// </summary>
+        /// <value>The activity ID.</value>
+        public string ActivityID { get; set; } = string.Empty;
 
         public void SetPrincipal(AppPrincipal principal)
         {

--- a/src/Arc4u.Standard/Security/Principal/ApplicationInstanceContext.cs
+++ b/src/Arc4u.Standard/Security/Principal/ApplicationInstanceContext.cs
@@ -15,6 +15,12 @@ namespace Arc4u.Security.Principal
             Principal = principal;
         }
 
+        /// <summary>
+        /// Gets or sets the activity ID.
+        /// </summary>
+        /// <value>The activity ID.</value>
+        public string ActivityID { get; set; } = string.Empty;
+
         public AppPrincipal Principal { get; private set; }
     }
 }

--- a/src/Arc4u.Standard/Security/Principal/IApplicationContext.cs
+++ b/src/Arc4u.Standard/Security/Principal/IApplicationContext.cs
@@ -1,8 +1,14 @@
-﻿namespace Arc4u.Security.Principal
+namespace Arc4u.Security.Principal
 {
     public interface IApplicationContext
     {
         AppPrincipal Principal { get; }
+
+        /// <summary>
+        /// Gets or sets the activity ID.
+        /// </summary>
+        /// <value>The activity ID.</value>
+        string ActivityID { get; set; }
 
         void SetPrincipal(AppPrincipal principal);
     }


### PR DESCRIPTION
Today, the ActivityId is associated with an [AppPrincipal](https://github.com/GFlisch/Arc4u/blob/fdddf2e795e700b8baf1e238eb795011523d3cf2/src/Arc4u.Standard/Security/Principal/AppPrincipal.cs#L136):

~~~csharp
        /// <summary>
        /// Gets or sets the activity ID.
        /// </summary>
        /// <value>The activity ID.</value>
        public string ActivityID { get; set; } = string.Empty;
~~~

Conceptually, an activity id by its very nature is independent of  an `AppPrincipal`. This means that the existence of an activity id is independent of the existence of an application principal. 
Especially for logging messages in situations where (for some reason) an `AppPrincipal` is not (yet) available (and therefore `null`), this is difficult and yields unexpected "null reference" errors. 

This pull request moves the `ActivityID` property to the `IApplicationContext` interface: an instance of this interface exists independently of an `AppPrincipal`. This is more logical.

Technically, this is a breaking change, but a survey of the existing code found only 92 occurrences, all of them on old pre-.NET Core projects. The current code base is therefore not impacted: all `ActivityId` access happens inside Arc4u.

>While writing this pull request, I considered changing the type of `ActivityId` from `string` to `System.Diagnostics.Activity` since this type is richer than just its `Id` and it's available anyway. But this change has a larger impact, especially on memory pressure when nested activities are present.
