### PR TITLE
Add Trace/LogTrace and Critical/LogCritical

### DIFF
--- a/src/Arc4u.Standard.Diagnostics/Fluent/Common/CommonMessageLogger.cs
+++ b/src/Arc4u.Standard.Diagnostics/Fluent/Common/CommonMessageLogger.cs
@@ -115,7 +115,9 @@ namespace Arc4u.Diagnostics
 
         internal CommonLoggerProperties System(string message, params object[] args)
         {
-            return AddEntry(LogLevel.Trace, message, null, args);
+            var buildMessage = AddEntry(LogLevel.Trace, message, null, args);
+            buildMessage.Add("Arc4u", "Internal");  // to disambiguate between system logging inside Arc4u and user logging.
+            return buildMessage;
         }
     }
 }

--- a/src/Arc4u.Standard.Diagnostics/Fluent/Common/CommonMessageLogger.cs
+++ b/src/Arc4u.Standard.Diagnostics/Fluent/Common/CommonMessageLogger.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
 using System;
+using Microsoft.Extensions.Logging;
 
 namespace Arc4u.Diagnostics
 {
@@ -56,11 +56,24 @@ namespace Arc4u.Diagnostics
             buildMessage.Log();
         }
 
+        public CommonLoggerProperties Critical(string message, params object[] args)
+        {
+            return AddEntry(LogLevel.Critical, message, null, args);
+        }
+
+        public void LogCritical(string message, params object[] args)
+        {
+            var buildMessage = AddEntry(LogLevel.Critical, message, null, args);
+            buildMessage.Log();
+        }
+
+        [Obsolete("This method is obsolete. Use Critical() instead")]
         public CommonLoggerProperties Fatal(string message, params object[] args)
         {
             return AddEntry(LogLevel.Critical, message, null, args);
         }
 
+        [Obsolete("This method is obsolete. Use LogCritical() instead")]
         public void LogFatal(string message, params object[] args)
         {
             var buildMessage = AddEntry(LogLevel.Critical, message, null, args);
@@ -87,6 +100,17 @@ namespace Arc4u.Diagnostics
         public void LogException(Exception exception)
         {
             Exception(exception).Log();
+        }
+
+        internal CommonLoggerProperties Trace(string message, params object[] args)
+        {
+            return AddEntry(LogLevel.Trace, message, null, args);
+        }
+
+        internal void LogTrace(string message, params object[] args)
+        {
+            var buildMessage = AddEntry(LogLevel.Trace, message, null, args);
+            buildMessage.Log();
         }
 
         internal CommonLoggerProperties System(string message, params object[] args)

--- a/src/Arc4u.Standard.Diagnostics/Fluent/Monitor/MonitoringMessageLogger.cs
+++ b/src/Arc4u.Standard.Diagnostics/Fluent/Monitor/MonitoringMessageLogger.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
 using System;
+using Microsoft.Extensions.Logging;
 
 namespace Arc4u.Diagnostics
 {
@@ -33,6 +33,11 @@ namespace Arc4u.Diagnostics
         public MonitoringLoggerProperties Information(string message)
         {
             return AddEntry(LogLevel.Information, message);
+        }
+
+        public MonitoringLoggerProperties Trace(string message)
+        {
+            return AddEntry(LogLevel.Trace, message);
         }
 
         internal MonitoringLoggerProperties System(string message)

--- a/src/Arc4u.Standard.NServiceBus/Diagnostics/LoggerBridge.cs
+++ b/src/Arc4u.Standard.NServiceBus/Diagnostics/LoggerBridge.cs
@@ -51,18 +51,18 @@ namespace Arc4u.NServiceBus.Diagnostics
 
         public void Fatal(string message)
         {
-            LoggerBase.Technical.From<LoggerBridge>().Fatal(message).Log();
+            LoggerBase.Technical.From<LoggerBridge>().Critical(message).Log();
         }
 
         public void Fatal(string message, Exception exception)
         {
-            LoggerBase.Technical.From<LoggerBridge>().Fatal(message).Log();
+            LoggerBase.Technical.From<LoggerBridge>().Critical(message).Log();
             LoggerBase.Technical.From<LoggerBridge>().Exception(exception).Log();
         }
 
         public void FatalFormat(string format, params object[] args)
         {
-            LoggerBase.Technical.From<LoggerBridge>().Fatal(String.Format(format, args)).Log();
+            LoggerBase.Technical.From<LoggerBridge>().Critical(String.Format(format, args)).Log();
         }
 
         public void Info(string message)

--- a/src/Arc4u.Standard.Results/Logging/FluentLogger.cs
+++ b/src/Arc4u.Standard.Results/Logging/FluentLogger.cs
@@ -112,7 +112,7 @@ public class FluentLogger : IResultLogger
         LogLevel.Information => _logger.Business().Information,
         LogLevel.Warning => _logger.Business().Warning,
         LogLevel.Error => _logger.Business().Error,
-        LogLevel.Critical => _logger.Business().Fatal,
+        LogLevel.Critical => _logger.Business().Critical,
         LogLevel.None => _logger.Business().Debug,
         _ => _logger.Business().Debug,
     };

--- a/src/Arc4u.Standard.UnitTest/Logging/SerilogTests.cs
+++ b/src/Arc4u.Standard.UnitTest/Logging/SerilogTests.cs
@@ -37,7 +37,7 @@ public class SerilogTests : BaseContainerFixture<SerilogTests, BasicFixture>
                 logger.Technical().LogInformation("Information {Code}", 101);
                 logger.Technical().LogWarning("Warning {Code}", 102);
                 logger.Technical().LogError("Error {Code}", 103);
-                logger.Technical().LogFatal("Fatal {Code}", 104);
+                logger.Technical().LogCritical("Fatal {Code}", 104);
                 logger.Technical().LogException(new DivideByZeroException("Cannot divide by zero"));
 
                 await Task.Delay(1000);
@@ -68,7 +68,7 @@ public class SerilogTests : BaseContainerFixture<SerilogTests, BasicFixture>
                 logger.Technical().Information("Information").Add("Code", "101").Log();
                 logger.Technical().Warning("Warning").Add("Code", "102").Log();
                 logger.Technical().Error("Error").Add("Code", "103").Log();
-                logger.Technical().Fatal("Fatal").Add("Code", "104").Log();
+                logger.Technical().Critical("Fatal").Add("Code", "104").Log();
                 logger.Technical().Exception(new DivideByZeroException("Cannot divide by zero")).Log();
                 logger.Monitoring().Debug("Memory").AddMemoryUsage().Log();
 

--- a/src/Arc4u.Standard/ServiceModel/Messages.cs
+++ b/src/Arc4u.Standard/ServiceModel/Messages.cs
@@ -91,7 +91,7 @@ namespace Arc4u.ServiceModel
                         property = categoryLogger.Error(lm.Text);
                         break;
                     case MessageType.Critical:
-                        property = categoryLogger.Fatal(lm.Text);
+                        property = categoryLogger.Critical(lm.Text);
                         break;
                     default:
                         property = categoryLogger.Debug(lm.Text);


### PR DESCRIPTION
(1)
There is a naming anomaly in CommonMessageLogger that violates the *principle of least astonishment*:
- `LogLevel.Information` -level messages are added by methods `Information`/`LogInformation`: OK!
- `LogLevel.Warning` -level messages are added by methods `Warning`/`LogWarning`: OK!
- `LogLevel.Error` -level messages are added by methods `Error`/`LogError`: OK!

but:
- `LogLevel.Critical` -level messages are added by methods `Fatal`/`LogFatal`: ASTONISHING!

This pull request adds the expected `Critical`/`LogCritical` methods for `LogLevel.Critical`-level messages, and declares the `Fatal`/`LogFatal` as obsolete. All references to the latter in Arc4u are changed appropriately.

(2)
There is no accessible method to log `Loglevel.Trace`-level messages. The `System` method uses this log level, but it's only for internal Arc4u use. However, it is legitimate for user core to log `LogLevel-Trace`-level messages.

This pull request adds the `Trace`/`LogTrace` methods for `LogLevel-Trace`-level messages, accessible in user code.
The `System` method still exists, but contains a structured property `"Arc4u"` with value `"Internal"` to be able to disambiguate those logs messages if needed.