### PR TITLE
More efficient AddIf with function delegates

### DIFF
--- a/src/Arc4u.Standard.Diagnostics/Fluent/Common/CommonLoggerProperties.cs
+++ b/src/Arc4u.Standard.Diagnostics/Fluent/Common/CommonLoggerProperties.cs
@@ -20,12 +20,6 @@ namespace Arc4u.Diagnostics
             return this;
         }
 
-        public CommonLoggerProperties AddIf(bool condition, string key, Func<int> value)
-        {
-            if (condition) AddProperty(key, value());
-            return this;
-        }
-
         public CommonLoggerProperties Add(string key, double value)
         {
             AddProperty(key, value);
@@ -35,12 +29,6 @@ namespace Arc4u.Diagnostics
         public CommonLoggerProperties AddIf(bool condition, string key, double value)
         {
             if (condition) AddProperty(key, value);
-            return this;
-        }
-
-        public CommonLoggerProperties AddIf(bool condition, string key, Func<double> value)
-        {
-            if (condition) AddProperty(key, value());
             return this;
         }
 
@@ -56,12 +44,6 @@ namespace Arc4u.Diagnostics
             return this;
         }
 
-        public CommonLoggerProperties AddIf(bool condition, string key, Func<bool> value)
-        {
-            if (condition) AddProperty(key, value());
-            return this;
-        }
-
         public CommonLoggerProperties Add(string key, long value)
         {
             AddProperty(key, value);
@@ -74,12 +56,6 @@ namespace Arc4u.Diagnostics
             return this;
         }
 
-        public CommonLoggerProperties AddIf(bool condition, string key, Func<long> value)
-        {
-            if (condition) AddProperty(key, value());
-            return this;
-        }
-
         public CommonLoggerProperties Add(string key, string value)
         {
             AddProperty(key, value);
@@ -89,12 +65,6 @@ namespace Arc4u.Diagnostics
         public CommonLoggerProperties AddIf(bool condition, string key, string value)
         {
             if (condition) AddProperty(key, value);
-            return this;
-        }
-
-        public CommonLoggerProperties AddIf(bool condition, string key, Func<string> value)
-        {
-            if (condition) AddProperty(key, value());
             return this;
         }
 

--- a/src/Arc4u.Standard.Diagnostics/Fluent/Common/CommonLoggerProperties.cs
+++ b/src/Arc4u.Standard.Diagnostics/Fluent/Common/CommonLoggerProperties.cs
@@ -20,6 +20,12 @@ namespace Arc4u.Diagnostics
             return this;
         }
 
+        public CommonLoggerProperties AddIf(bool condition, string key, Func<int> value)
+        {
+            if (condition) AddProperty(key, value());
+            return this;
+        }
+
         public CommonLoggerProperties Add(string key, double value)
         {
             AddProperty(key, value);
@@ -29,6 +35,12 @@ namespace Arc4u.Diagnostics
         public CommonLoggerProperties AddIf(bool condition, string key, double value)
         {
             if (condition) AddProperty(key, value);
+            return this;
+        }
+
+        public CommonLoggerProperties AddIf(bool condition, string key, Func<double> value)
+        {
+            if (condition) AddProperty(key, value());
             return this;
         }
 
@@ -44,6 +56,12 @@ namespace Arc4u.Diagnostics
             return this;
         }
 
+        public CommonLoggerProperties AddIf(bool condition, string key, Func<bool> value)
+        {
+            if (condition) AddProperty(key, value());
+            return this;
+        }
+
         public CommonLoggerProperties Add(string key, long value)
         {
             AddProperty(key, value);
@@ -56,6 +74,12 @@ namespace Arc4u.Diagnostics
             return this;
         }
 
+        public CommonLoggerProperties AddIf(bool condition, string key, Func<long> value)
+        {
+            if (condition) AddProperty(key, value());
+            return this;
+        }
+
         public CommonLoggerProperties Add(string key, string value)
         {
             AddProperty(key, value);
@@ -65,6 +89,12 @@ namespace Arc4u.Diagnostics
         public CommonLoggerProperties AddIf(bool condition, string key, string value)
         {
             if (condition) AddProperty(key, value);
+            return this;
+        }
+
+        public CommonLoggerProperties AddIf(bool condition, string key, Func<string> value)
+        {
+            if (condition) AddProperty(key, value());
             return this;
         }
 

--- a/src/Arc4u.Standard.Diagnostics/Fluent/Common/CommonLoggerProperties.cs
+++ b/src/Arc4u.Standard.Diagnostics/Fluent/Common/CommonLoggerProperties.cs
@@ -20,6 +20,12 @@ namespace Arc4u.Diagnostics
             return this;
         }
 
+        public CommonLoggerProperties AddIf(bool condition, string key, Func<int> value)
+        {
+            if (condition) AddProperty(key, value());
+            return this;
+        }
+
         public CommonLoggerProperties Add(string key, double value)
         {
             AddProperty(key, value);
@@ -32,6 +38,14 @@ namespace Arc4u.Diagnostics
             return this;
         }
 
+        public CommonLoggerProperties AddIf(bool condition, string key, Func<double> value)
+        {
+            if (condition) AddProperty(key, value());
+            return this;
+        }
+
+
+
         public CommonLoggerProperties Add(string key, bool value)
         {
             AddProperty(key, value);
@@ -41,6 +55,12 @@ namespace Arc4u.Diagnostics
         public CommonLoggerProperties AddIf(bool condition, string key, bool value)
         {
             if (condition) AddProperty(key, value);
+            return this;
+        }
+
+        public CommonLoggerProperties AddIf(bool condition, string key, Func<bool> value)
+        {
+            if (condition) AddProperty(key, value());
             return this;
         }
 
@@ -56,6 +76,13 @@ namespace Arc4u.Diagnostics
             return this;
         }
 
+        public CommonLoggerProperties AddIf(bool condition, string key, Func<long> value)
+        {
+            if (condition) AddProperty(key, value());
+            return this;
+        }
+
+
         public CommonLoggerProperties Add(string key, string value)
         {
             AddProperty(key, value);
@@ -65,6 +92,12 @@ namespace Arc4u.Diagnostics
         public CommonLoggerProperties AddIf(bool condition, string key, string value)
         {
             if (condition) AddProperty(key, value);
+            return this;
+        }
+
+        public CommonLoggerProperties AddIf(bool condition, string key, Func<string> value)
+        {
+            if (condition) AddProperty(key, value());
             return this;
         }
 


### PR DESCRIPTION
Fluent logging has the capability of conditionally adding a property, using `AddIf`, [like so](https://github.com/GFlisch/Arc4u/blob/fdddf2e795e700b8baf1e238eb795011523d3cf2/src/Arc4u.Standard.Diagnostics/Fluent/Common/CommonLoggerProperties.cs#L65):

~~~csharp
public CommonLoggerProperties AddIf(bool condition, string key, string value)
~~~

The downside of this method is that the `value` argument needs to be specified, even when `condition` is `false`. If  `value` is the result of an expensive operation:

~~~csharp
...AddIf(condition,"MyKey", ComputeExpensiveValueForDebugging(otherParameters));
~~~

... then that expensive operation (`ComputeExpensiveValueForDebugging(otherParameters)` in this case) will be computed regardless of the value of the `condition` parameter.

To avoid this, this pull request provides for each overload of `AddIf` a corresponding overload with a function delegate as value parameter. For example:

~~~csharp
public CommonLoggerProperties AddIf(bool condition, string key, Func<string> value)
~~~

This way, the previous call can be written as:

~~~csharp
...AddIf(condition,"MyKey", () => ComputeExpensiveValueForDebugging(otherParameters));
~~~

This way, `ComputeExpensiveValueForDebugging(otherParameters)` will only be called when `condition` is `true`. Nothing will be called if `someCondition` is `false`.
