### PR TITLE
Remove all traces of Newtonsoft.

### DIFF
--- a/src/Arc4u.Standard.Dependency/Arc4u.Standard.Dependency.csproj
+++ b/src/Arc4u.Standard.Dependency/Arc4u.Standard.Dependency.csproj
@@ -33,9 +33,6 @@
     <None Remove="Builder\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.*" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\Arc4u.Standard.Diagnostics\Arc4u.Standard.Diagnostics.csproj" />
     <ProjectReference Include="..\Arc4u.Standard.Threading\Arc4u.Standard.Threading.csproj" />
   </ItemGroup>

--- a/src/Arc4u.Standard.Diagnostics/Fluent/Common/CommonLoggerProperties.cs
+++ b/src/Arc4u.Standard.Diagnostics/Fluent/Common/CommonLoggerProperties.cs
@@ -20,12 +20,6 @@ namespace Arc4u.Diagnostics
             return this;
         }
 
-        public CommonLoggerProperties AddIf(bool condition, string key, Func<int> value)
-        {
-            if (condition) AddProperty(key, value());
-            return this;
-        }
-
         public CommonLoggerProperties Add(string key, double value)
         {
             AddProperty(key, value);
@@ -35,12 +29,6 @@ namespace Arc4u.Diagnostics
         public CommonLoggerProperties AddIf(bool condition, string key, double value)
         {
             if (condition) AddProperty(key, value);
-            return this;
-        }
-
-        public CommonLoggerProperties AddIf(bool condition, string key, Func<double> value)
-        {
-            if (condition) AddProperty(key, value());
             return this;
         }
 
@@ -56,12 +44,6 @@ namespace Arc4u.Diagnostics
             return this;
         }
 
-        public CommonLoggerProperties AddIf(bool condition, string key, Func<bool> value)
-        {
-            if (condition) AddProperty(key, value());
-            return this;
-        }
-
         public CommonLoggerProperties Add(string key, long value)
         {
             AddProperty(key, value);
@@ -74,12 +56,6 @@ namespace Arc4u.Diagnostics
             return this;
         }
 
-        public CommonLoggerProperties AddIf(bool condition, string key, Func<long> value)
-        {
-            if (condition) AddProperty(key, value());
-            return this;
-        }
-
         public CommonLoggerProperties Add(string key, string value)
         {
             AddProperty(key, value);
@@ -89,12 +65,6 @@ namespace Arc4u.Diagnostics
         public CommonLoggerProperties AddIf(bool condition, string key, string value)
         {
             if (condition) AddProperty(key, value);
-            return this;
-        }
-
-        public CommonLoggerProperties AddIf(bool condition, string key, Func<string> value)
-        {
-            if (condition) AddProperty(key, value());
             return this;
         }
 

--- a/src/Arc4u.Standard.Diagnostics/Fluent/Common/CommonLoggerProperties.cs
+++ b/src/Arc4u.Standard.Diagnostics/Fluent/Common/CommonLoggerProperties.cs
@@ -20,6 +20,12 @@ namespace Arc4u.Diagnostics
             return this;
         }
 
+        public CommonLoggerProperties AddIf(bool condition, string key, Func<int> value)
+        {
+            if (condition) AddProperty(key, value());
+            return this;
+        }
+
         public CommonLoggerProperties Add(string key, double value)
         {
             AddProperty(key, value);
@@ -29,6 +35,12 @@ namespace Arc4u.Diagnostics
         public CommonLoggerProperties AddIf(bool condition, string key, double value)
         {
             if (condition) AddProperty(key, value);
+            return this;
+        }
+
+        public CommonLoggerProperties AddIf(bool condition, string key, Func<double> value)
+        {
+            if (condition) AddProperty(key, value());
             return this;
         }
 
@@ -44,6 +56,12 @@ namespace Arc4u.Diagnostics
             return this;
         }
 
+        public CommonLoggerProperties AddIf(bool condition, string key, Func<bool> value)
+        {
+            if (condition) AddProperty(key, value());
+            return this;
+        }
+
         public CommonLoggerProperties Add(string key, long value)
         {
             AddProperty(key, value);
@@ -56,6 +74,12 @@ namespace Arc4u.Diagnostics
             return this;
         }
 
+        public CommonLoggerProperties AddIf(bool condition, string key, Func<long> value)
+        {
+            if (condition) AddProperty(key, value());
+            return this;
+        }
+
         public CommonLoggerProperties Add(string key, string value)
         {
             AddProperty(key, value);
@@ -65,6 +89,12 @@ namespace Arc4u.Diagnostics
         public CommonLoggerProperties AddIf(bool condition, string key, string value)
         {
             if (condition) AddProperty(key, value);
+            return this;
+        }
+
+        public CommonLoggerProperties AddIf(bool condition, string key, Func<string> value)
+        {
+            if (condition) AddProperty(key, value());
             return this;
         }
 

--- a/src/Arc4u.Standard/Exceptions/AppException.cs
+++ b/src/Arc4u.Standard/Exceptions/AppException.cs
@@ -1,10 +1,10 @@
-﻿using Arc4u.ServiceModel;
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Text;
+using System.Text.Json;
 using System.Threading.Tasks;
+using Arc4u.ServiceModel;
 
 namespace Arc4u
 {
@@ -97,14 +97,14 @@ namespace Arc4u
             IEnumerable<Message> messages = null;
             try
             {
-                messages = JsonConvert.DeserializeObject<IEnumerable<Message>>(content);
+                messages = JsonSerializer.Deserialize<IEnumerable<Message>>(content);
             }
             catch (Exception)
             {
                 // transform the old format to new one.
                 content = content.Replace("\"Category\":\"Described\"", "\"Category\":\"Business\"");
                 content = content.Replace("\"Category\":\"Undescribed\"", "\"Category\":\"Technical\"");
-                messages = JsonConvert.DeserializeObject<IEnumerable<Message>>(content);
+                messages = JsonSerializer.Deserialize<IEnumerable<Message>>(content);
             }
 
             throw new AppException(messages);

--- a/src/Arc4u.Standard/Security/Principal/UserProfile.cs
+++ b/src/Arc4u.Standard/Security/Principal/UserProfile.cs
@@ -1,7 +1,7 @@
-﻿using Newtonsoft.Json;
 using System;
 using System.Globalization;
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 using System.Xml;
 using System.Xml.Serialization;
 
@@ -117,7 +117,6 @@ namespace Arc4u.Security.Principal
         #region IProfile Members
 
         [DataMember]
-        [JsonProperty]
         public String DisplayName { get; private set; }
 
         /// <summary>
@@ -125,7 +124,6 @@ namespace Arc4u.Security.Principal
         /// </summary>
         /// <value>The email.</value>
         [DataMember]
-        [JsonProperty]
         public String Email { get; private set; }
 
         /// <summary>
@@ -133,7 +131,6 @@ namespace Arc4u.Security.Principal
         /// </summary>
         /// <value>The department.</value>
         [DataMember]
-        [JsonProperty]
         public string Department { get; private set; }
 
         /// <summary>
@@ -141,7 +138,6 @@ namespace Arc4u.Security.Principal
         /// </summary>
         /// <value>The company.</value>
         [DataMember]
-        [JsonProperty]
         public string Company { get; private set; }
 
         /// <summary>
@@ -149,7 +145,6 @@ namespace Arc4u.Security.Principal
         /// </summary>
         /// <value>The name of the given.</value>
         [DataMember]
-        [JsonProperty]
         public string GivenName { get; private set; }
 
         /// <summary>
@@ -157,7 +152,6 @@ namespace Arc4u.Security.Principal
         /// </summary>
         /// <value>The surname.</value>
         [DataMember]
-        [JsonProperty]
         public string SurName { get; private set; }
 
         /// <summary>
@@ -165,7 +159,6 @@ namespace Arc4u.Security.Principal
         /// </summary>
         /// <value>The sid.</value>
         [DataMember]
-        [JsonProperty]
         public String Sid { get; private set; }
 
         /// <summary>
@@ -173,7 +166,6 @@ namespace Arc4u.Security.Principal
         /// </summary>
         /// <value>The state.</value>
         [DataMember]
-        [JsonProperty]
         public string State { get; private set; }
 
         /// <summary>
@@ -181,84 +173,73 @@ namespace Arc4u.Security.Principal
         /// </summary>
         /// <value>The mobile.</value>
         [DataMember]
-        [JsonProperty]
         public string Mobile { get; private set; }
         /// <summary>
         /// Gets the telephone.
         /// </summary>
         /// <value>The telephone.</value>
         [DataMember]
-        [JsonProperty]
         public string Telephone { get; private set; }
         /// <summary>
         /// Gets the internal phone.
         /// </summary>
         /// <value>The internal phone.</value>
         [DataMember]
-        [JsonProperty]
         public string InternalPhone { get; private set; }
         /// <summary>
         /// Gets the fax.
         /// </summary>
         /// <value>The fax.</value>
         [DataMember]
-        [JsonProperty]
         public string Fax { get; private set; }
         /// <summary>
         /// Gets the name of the principal.
         /// </summary>
         /// <value>The name of the principal.</value>
         [DataMember]
-        [JsonProperty]
         public string PrincipalName { get; private set; }
         /// <summary>
         /// Gets the postal code.
         /// </summary>
         /// <value>The postal code.</value>
         [DataMember]
-        [JsonProperty]
         public string PostalCode { get; private set; }
 
         /// <summary>
         /// Get the Street defined in the address.
         /// </summary>
         [DataMember]
-        [JsonProperty]
         public String Street { get; private set; }
         /// <summary>
         /// Gets the room.
         /// </summary>
         /// <value>The room.</value>
         [DataMember]
-        [JsonProperty]
         public string Room { get; private set; }
         /// <summary>
         /// Gets the initials.
         /// </summary>
         /// <value>The initials.</value>
         [DataMember]
-        [JsonProperty]
         public string Initials { get; private set; }
         /// <summary>
         /// Gets the name of the sam account.
         /// </summary>
         /// <value>The name of the sam account.</value>
         [DataMember]
-        [JsonProperty]
         public string SamAccountName { get; private set; }
 
         /// <summary>
         /// Get the domain.
         /// </summary>
         [DataMember]
-        [JsonProperty]
         public string Domain { get; private set; }
         /// <summary>
         /// Gets the culture.
         /// </summary>
         /// <value>The culture.</value>
         [DataMember(Name = "Culture")]
-        [JsonProperty(PropertyName = "Culture")]
+        [JsonPropertyName("Culture")]
         private string _culture;
 
         [IgnoreDataMember]
@@ -273,7 +254,7 @@ namespace Arc4u.Security.Principal
         /// </summary>
         /// <value>The current culture.</value>
         [DataMember(Name = "CurrentCulture")]
-        [JsonProperty(PropertyName = "CurrentCulture")]
+        [JsonPropertyName("CurrentCulture")]
         private string _currentCulture;
 
         [IgnoreDataMember]
@@ -289,14 +270,12 @@ namespace Arc4u.Security.Principal
         /// </summary>
         /// <value>The name of the common.</value>
         [DataMember]
-        [JsonProperty]
         public string CommonName { get; private set; }
         /// <summary>
         /// Gets the description.
         /// </summary>
         /// <value>The description.</value>
         [DataMember]
-        [JsonProperty]
         public string Description { get; private set; }
 
         #endregion

--- a/src/Arc4u.Standard/ServiceModel/MessageCategoryConverter.cs
+++ b/src/Arc4u.Standard/ServiceModel/MessageCategoryConverter.cs
@@ -1,6 +1,6 @@
-﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Arc4u.ServiceModel
 {
@@ -8,94 +8,63 @@ namespace Arc4u.ServiceModel
     /// This class is used with json to Deserialize a <see cref="Message"/> class and change the Category from a 
     /// <see cref="String"/> to a <see cref="MessageCategory"/> type.
     /// </summary>
-    public class MessageCategoryConverter : CustomCreationConverter<Message>
+    public class MessageCategoryConverter : JsonConverter<Message>
     {
-        public override Message Create(Type objectType)
+        /// <summary>
+        /// This is what the serialized message looks like
+        /// </summary>
+        private sealed class OldMessage
         {
-            return new Message();
+            private const string DescribedCategory = "Described";
+            private const string UndescribedCategory = "Undescribed";
+
+            public string Code { get; set; }
+            public string Text { get; set; }
+            public string Subject { get; set; }
+            public string Category { get; set; }
+            public int Type { get; set; }
+
+            /// <summary>
+            /// Default constructor for serialization
+            /// </summary>
+            public OldMessage()
+            {
+            }
+
+            /// <summary>
+            /// Conversion constructor
+            /// </summary>
+            /// <param name="message"></param>
+            public OldMessage(Message message)
+            {
+                Code = message.Code;
+                Text = message.Text;
+                Subject = message.Subject;
+                Category = message.Category == MessageCategory.Business ? DescribedCategory : UndescribedCategory;
+                Type = (int)message.Type;
+            }
+
+            /// <summary>
+            /// Conversion operator for the actual message formar
+            /// </summary>
+            /// <returns></returns>
+            public Message ToMessage()
+            {
+                return new Message(StringComparer.OrdinalIgnoreCase.Equals(Category, DescribedCategory) ? MessageCategory.Business : MessageCategory.Technical, (MessageType)Type, Code, Subject, Text);
+            }
         }
 
-        public override bool CanRead => true;
-        public override bool CanWrite => true;
-
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        public override Message Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            var code = String.Empty;
-            var text = String.Empty;
-            var subject = String.Empty;
-            var category = MessageCategory.Technical;
-            var type = MessageType.Information;
-
-
-            while (reader.Read())
-            {
-                var tokenType = reader.TokenType;
-
-                if (tokenType == JsonToken.PropertyName)
-                {
-                    var propertyName = reader.Value.ToString();
-
-                    // Key/value pattern.
-
-                    if (propertyName.Equals("code", StringComparison.CurrentCultureIgnoreCase))
-                        code = reader.ReadAsString();
-                    else if (propertyName.Equals("text", StringComparison.CurrentCultureIgnoreCase))
-                        text = reader.ReadAsString();
-                    else if (propertyName.Equals("subject", StringComparison.CurrentCultureIgnoreCase))
-                        subject = reader.ReadAsString();
-                    else if (propertyName.Equals("category", StringComparison.CurrentCultureIgnoreCase))
-                        category = reader.ReadAsString().Equals("described", StringComparison.CurrentCultureIgnoreCase) ? MessageCategory.Business : MessageCategory.Technical;
-                    else if (propertyName.Equals("type", StringComparison.CurrentCultureIgnoreCase))
-                        type = (MessageType)reader.ReadAsInt32();
-                }
-
-                if (tokenType == JsonToken.EndObject)
-                    return new Message(category, type, code, subject, text);
-            }
-
-            return new Message();
+            var oldMessage = JsonSerializer.Deserialize<OldMessage>(ref reader, options);
+            // the previous implementation always returned a non-null message which is dangerous.
+            return oldMessage?.ToMessage();
         }
 
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        public override void Write(Utf8JsonWriter writer, Message message, JsonSerializerOptions options)
         {
-            var message = value as Message;
-
-            if (null == message)
-            {
-                base.WriteJson(writer, value, serializer);
-                return;
-            }
-
-            // Serialize the message object.           
-            writer.WriteStartObject();
-
-            if (!String.IsNullOrWhiteSpace(message.Code))
-            {
-                writer.WriteToken(JsonToken.PropertyName, "Code");
-                writer.WriteValue(message.Code);
-            }
-
-            if (!String.IsNullOrWhiteSpace(message.Subject))
-            {
-                writer.WriteToken(JsonToken.PropertyName, "Subject");
-                writer.WriteValue(message.Subject);
-            }
-
-            if (!String.IsNullOrWhiteSpace(message.Text))
-            {
-                writer.WriteToken(JsonToken.PropertyName, "Text");
-                writer.WriteValue(message.Text);
-            }
-
-            writer.WriteToken(JsonToken.PropertyName, "Type");
-            writer.WriteValue(message.Type);
-
-            writer.WriteToken(JsonToken.PropertyName, "Category");
-            writer.WriteValue(message.Category == MessageCategory.Business ? "Described" : "Undescribed");
-
-
-            writer.WriteEndObject();
+            var oldMessage = message is null ? null : new OldMessage(message);
+            JsonSerializer.Serialize(writer, oldMessage, options);
         }
-
     }
 }


### PR DESCRIPTION
This pull request removes `Newtonsoft`, and replaces it with `System.Text.Json` for JSON serialization..

Since Arc4u is also used in Blazor, it pays off to minimize dependencies. Today, clients have 2 dependencies on Newtonsoft: Arc4u and NSwag. After this PR, we have only one!
