### PR TITLE
System.IdentityModel.Tokens.Jwt vulnerability

### DIFF
--- a/src/Arc4u.Standard.Diagnostics/Fluent/Common/CommonLoggerProperties.cs
+++ b/src/Arc4u.Standard.Diagnostics/Fluent/Common/CommonLoggerProperties.cs
@@ -20,12 +20,6 @@ namespace Arc4u.Diagnostics
             return this;
         }
 
-        public CommonLoggerProperties AddIf(bool condition, string key, Func<int> value)
-        {
-            if (condition) AddProperty(key, value());
-            return this;
-        }
-
         public CommonLoggerProperties Add(string key, double value)
         {
             AddProperty(key, value);
@@ -35,12 +29,6 @@ namespace Arc4u.Diagnostics
         public CommonLoggerProperties AddIf(bool condition, string key, double value)
         {
             if (condition) AddProperty(key, value);
-            return this;
-        }
-
-        public CommonLoggerProperties AddIf(bool condition, string key, Func<double> value)
-        {
-            if (condition) AddProperty(key, value());
             return this;
         }
 
@@ -56,12 +44,6 @@ namespace Arc4u.Diagnostics
             return this;
         }
 
-        public CommonLoggerProperties AddIf(bool condition, string key, Func<bool> value)
-        {
-            if (condition) AddProperty(key, value());
-            return this;
-        }
-
         public CommonLoggerProperties Add(string key, long value)
         {
             AddProperty(key, value);
@@ -74,12 +56,6 @@ namespace Arc4u.Diagnostics
             return this;
         }
 
-        public CommonLoggerProperties AddIf(bool condition, string key, Func<long> value)
-        {
-            if (condition) AddProperty(key, value());
-            return this;
-        }
-
         public CommonLoggerProperties Add(string key, string value)
         {
             AddProperty(key, value);
@@ -89,12 +65,6 @@ namespace Arc4u.Diagnostics
         public CommonLoggerProperties AddIf(bool condition, string key, string value)
         {
             if (condition) AddProperty(key, value);
-            return this;
-        }
-
-        public CommonLoggerProperties AddIf(bool condition, string key, Func<string> value)
-        {
-            if (condition) AddProperty(key, value());
             return this;
         }
 

--- a/src/Arc4u.Standard.Diagnostics/Fluent/Common/CommonLoggerProperties.cs
+++ b/src/Arc4u.Standard.Diagnostics/Fluent/Common/CommonLoggerProperties.cs
@@ -20,6 +20,12 @@ namespace Arc4u.Diagnostics
             return this;
         }
 
+        public CommonLoggerProperties AddIf(bool condition, string key, Func<int> value)
+        {
+            if (condition) AddProperty(key, value());
+            return this;
+        }
+
         public CommonLoggerProperties Add(string key, double value)
         {
             AddProperty(key, value);
@@ -29,6 +35,12 @@ namespace Arc4u.Diagnostics
         public CommonLoggerProperties AddIf(bool condition, string key, double value)
         {
             if (condition) AddProperty(key, value);
+            return this;
+        }
+
+        public CommonLoggerProperties AddIf(bool condition, string key, Func<double> value)
+        {
+            if (condition) AddProperty(key, value());
             return this;
         }
 
@@ -44,6 +56,12 @@ namespace Arc4u.Diagnostics
             return this;
         }
 
+        public CommonLoggerProperties AddIf(bool condition, string key, Func<bool> value)
+        {
+            if (condition) AddProperty(key, value());
+            return this;
+        }
+
         public CommonLoggerProperties Add(string key, long value)
         {
             AddProperty(key, value);
@@ -56,6 +74,12 @@ namespace Arc4u.Diagnostics
             return this;
         }
 
+        public CommonLoggerProperties AddIf(bool condition, string key, Func<long> value)
+        {
+            if (condition) AddProperty(key, value());
+            return this;
+        }
+
         public CommonLoggerProperties Add(string key, string value)
         {
             AddProperty(key, value);
@@ -65,6 +89,12 @@ namespace Arc4u.Diagnostics
         public CommonLoggerProperties AddIf(bool condition, string key, string value)
         {
             if (condition) AddProperty(key, value);
+            return this;
+        }
+
+        public CommonLoggerProperties AddIf(bool condition, string key, Func<string> value)
+        {
+            if (condition) AddProperty(key, value());
             return this;
         }
 

--- a/src/Arc4u.Standard.OAuth.Msal/Arc4u.Standard.OAuth2.Msal.csproj
+++ b/src/Arc4u.Standard.OAuth.Msal/Arc4u.Standard.OAuth2.Msal.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="Globals">
     <SccProjectName>SAK</SccProjectName>
     <SccProvider>SAK</SccProvider>
@@ -28,7 +28,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Identity.Client" Version="4.57.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.0.*" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.1.*" />
     <ProjectReference Include="..\Arc4u.Standard.Diagnostics\Arc4u.Standard.Diagnostics.csproj" />
     <ProjectReference Include="..\Arc4u.Standard.OAuth2\Arc4u.Standard.OAuth2.csproj" />
     <ProjectReference Include="..\Arc4u.Standard\Arc4u.Standard.csproj" />

--- a/src/Arc4u.Standard.OAuth2.AspNetCore.Adal/Arc4u.Standard.OAuth2.AspNetCore.Adal.csproj
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore.Adal/Arc4u.Standard.OAuth2.AspNetCore.Adal.csproj
@@ -23,7 +23,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.3.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.0.*" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.1.*" />
     <PackageReference Include="System.Security.Cryptography.Cng" Version="5.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
   </ItemGroup>

--- a/src/Arc4u.Standard.OAuth2.AspNetCore.Authentication/Arc4u.Standard.OAuth2.AspNetCore.Authentication.csproj
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore.Authentication/Arc4u.Standard.OAuth2.AspNetCore.Authentication.csproj
@@ -28,14 +28,12 @@
     <PackageId>Arc4u.Standard.OAuth2.AspNetCore.Authentication</PackageId>
     <RootNamespace>$(MSBuildProjectName.Replace(" ", "_").Replace(".Standard", ""))</RootNamespace>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="7.0.*" />
-  </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.*" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.*" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="7.1.*" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="7.0.*" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.*" />
   </ItemGroup>

--- a/src/Arc4u.Standard.OAuth2.Client/Arc4u.Standard.OAuth2.Client.csproj
+++ b/src/Arc4u.Standard.OAuth2.Client/Arc4u.Standard.OAuth2.Client.csproj
@@ -28,7 +28,7 @@
     <RootNamespace>$(MSBuildProjectName.Replace(" ", "_").Replace(".Standard", ""))</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.0.*" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.1.*" />
     <PackageReference Include="System.Security.Cryptography.Cng" Version="5.0.*" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Arc4u.Standard.OAuth2/Arc4u.Standard.OAuth2.csproj
+++ b/src/Arc4u.Standard.OAuth2/Arc4u.Standard.OAuth2.csproj
@@ -29,7 +29,7 @@
     <RootNamespace>$(MSBuildProjectName.Replace(" ", "_").Replace(".Standard", ""))</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.0.*" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.1.*" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Arc4u.Standard.Caching\Arc4u.Standard.Caching.csproj" />


### PR DESCRIPTION
The `System.IdentityModel.Tokens.Jwt` package versions 7.0.* are vulnerable. References have been upgraded and other dependencies upgraded as well.