### PR TITLE
Add Trace/LogTrace and Critical/LogCritical

### DIFF
--- a/src/Arc4u.Standard.Diagnostics/Fluent/Common/CommonMessageLogger.cs
+++ b/src/Arc4u.Standard.Diagnostics/Fluent/Common/CommonMessageLogger.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
 using System;
+using Microsoft.Extensions.Logging;
 
 namespace Arc4u.Diagnostics
 {
@@ -56,11 +56,24 @@ namespace Arc4u.Diagnostics
             buildMessage.Log();
         }
 
+        public CommonLoggerProperties Critical(string message, params object[] args)
+        {
+            return AddEntry(LogLevel.Critical, message, null, args);
+        }
+
+        public void LogCritical(string message, params object[] args)
+        {
+            var buildMessage = AddEntry(LogLevel.Critical, message, null, args);
+            buildMessage.Log();
+        }
+
+        [Obsolete("This method is obsolete. Use Critical() instead")]
         public CommonLoggerProperties Fatal(string message, params object[] args)
         {
             return AddEntry(LogLevel.Critical, message, null, args);
         }
 
+        [Obsolete("This method is obsolete. Use LogCritical() instead")]
         public void LogFatal(string message, params object[] args)
         {
             var buildMessage = AddEntry(LogLevel.Critical, message, null, args);
@@ -89,9 +102,22 @@ namespace Arc4u.Diagnostics
             Exception(exception).Log();
         }
 
-        internal CommonLoggerProperties System(string message, params object[] args)
+        internal CommonLoggerProperties Trace(string message, params object[] args)
         {
             return AddEntry(LogLevel.Trace, message, null, args);
+        }
+
+        internal void LogTrace(string message, params object[] args)
+        {
+            var buildMessage = AddEntry(LogLevel.Trace, message, null, args);
+            buildMessage.Log();
+        }
+
+        internal CommonLoggerProperties System(string message, params object[] args)
+        {
+            var buildMessage = AddEntry(LogLevel.Trace, message, null, args);
+            buildMessage.Add("Arc4u", "Internal");  // to disambiguate between system logging inside Arc4u and user logging.
+            return buildMessage;
         }
     }
 }

--- a/src/Arc4u.Standard.Diagnostics/Fluent/Monitor/MonitoringMessageLogger.cs
+++ b/src/Arc4u.Standard.Diagnostics/Fluent/Monitor/MonitoringMessageLogger.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
 using System;
+using Microsoft.Extensions.Logging;
 
 namespace Arc4u.Diagnostics
 {
@@ -33,6 +33,11 @@ namespace Arc4u.Diagnostics
         public MonitoringLoggerProperties Information(string message)
         {
             return AddEntry(LogLevel.Information, message);
+        }
+
+        public MonitoringLoggerProperties Trace(string message)
+        {
+            return AddEntry(LogLevel.Trace, message);
         }
 
         internal MonitoringLoggerProperties System(string message)

--- a/src/Arc4u.Standard.NServiceBus/Diagnostics/LoggerBridge.cs
+++ b/src/Arc4u.Standard.NServiceBus/Diagnostics/LoggerBridge.cs
@@ -1,6 +1,7 @@
-﻿using Arc4u.Diagnostics;
-using NServiceBus.Logging;
 using System;
+using System.Globalization;
+using Arc4u.Diagnostics;
+using NServiceBus.Logging;
 using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
 namespace Arc4u.NServiceBus.Diagnostics
@@ -30,7 +31,7 @@ namespace Arc4u.NServiceBus.Diagnostics
 
         public void DebugFormat(string format, params object[] args)
         {
-            LoggerBase.Technical.From<LoggerBridge>().Debug(String.Format(format, args)).Log();
+            LoggerBase.Technical.From<LoggerBridge>().Debug(String.Format(CultureInfo.InvariantCulture, format, args)).Log();
         }
 
         public void Error(string message)
@@ -46,23 +47,23 @@ namespace Arc4u.NServiceBus.Diagnostics
 
         public void ErrorFormat(string format, params object[] args)
         {
-            LoggerBase.Technical.From<LoggerBridge>().Error(String.Format(format, args)).Log();
+            LoggerBase.Technical.From<LoggerBridge>().Error(String.Format(CultureInfo.InvariantCulture, format, args)).Log();
         }
 
         public void Fatal(string message)
         {
-            LoggerBase.Technical.From<LoggerBridge>().Fatal(message).Log();
+            LoggerBase.Technical.From<LoggerBridge>().Critical(message).Log();
         }
 
         public void Fatal(string message, Exception exception)
         {
-            LoggerBase.Technical.From<LoggerBridge>().Fatal(message).Log();
+            LoggerBase.Technical.From<LoggerBridge>().Critical(message).Log();
             LoggerBase.Technical.From<LoggerBridge>().Exception(exception).Log();
         }
 
         public void FatalFormat(string format, params object[] args)
         {
-            LoggerBase.Technical.From<LoggerBridge>().Fatal(String.Format(format, args)).Log();
+            LoggerBase.Technical.From<LoggerBridge>().Critical(String.Format(CultureInfo.InvariantCulture, format, args)).Log();
         }
 
         public void Info(string message)
@@ -78,7 +79,7 @@ namespace Arc4u.NServiceBus.Diagnostics
 
         public void InfoFormat(string format, params object[] args)
         {
-            LoggerBase.Technical.From<LoggerBridge>().Information(String.Format(format, args)).Log();
+            LoggerBase.Technical.From<LoggerBridge>().Information(String.Format(CultureInfo.InvariantCulture, format, args)).Log();
         }
 
         public void Warn(string message)
@@ -94,7 +95,7 @@ namespace Arc4u.NServiceBus.Diagnostics
 
         public void WarnFormat(string format, params object[] args)
         {
-            LoggerBase.Technical.From<LoggerBridge>().Warning(String.Format(format, args)).Log();
+            LoggerBase.Technical.From<LoggerBridge>().Warning(String.Format(CultureInfo.InvariantCulture, format, args)).Log();
         }
     }
 }

--- a/src/Arc4u.Standard.UnitTest/Logging/SerilogTests.cs
+++ b/src/Arc4u.Standard.UnitTest/Logging/SerilogTests.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using Arc4u.Diagnostics;
 using Arc4u.Diagnostics.Serilog;
 using Arc4u.UnitTest.Infrastructure;
@@ -5,10 +9,6 @@ using Microsoft.Extensions.Logging;
 using Serilog;
 using Serilog.Core;
 using Serilog.Events;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace Arc4u.UnitTest.Logging;
@@ -37,7 +37,7 @@ public class SerilogTests : BaseContainerFixture<SerilogTests, BasicFixture>
                 logger.Technical().LogInformation("Information {Code}", 101);
                 logger.Technical().LogWarning("Warning {Code}", 102);
                 logger.Technical().LogError("Error {Code}", 103);
-                logger.Technical().LogFatal("Fatal {Code}", 104);
+                logger.Technical().LogCritical("Fatal {Code}", 104);
                 logger.Technical().LogException(new DivideByZeroException("Cannot divide by zero"));
 
                 await Task.Delay(1000);
@@ -68,7 +68,7 @@ public class SerilogTests : BaseContainerFixture<SerilogTests, BasicFixture>
                 logger.Technical().Information("Information").Add("Code", "101").Log();
                 logger.Technical().Warning("Warning").Add("Code", "102").Log();
                 logger.Technical().Error("Error").Add("Code", "103").Log();
-                logger.Technical().Fatal("Fatal").Add("Code", "104").Log();
+                logger.Technical().Critical("Fatal").Add("Code", "104").Log();
                 logger.Technical().Exception(new DivideByZeroException("Cannot divide by zero")).Log();
                 logger.Monitoring().Debug("Memory").AddMemoryUsage().Log();
 

--- a/src/Arc4u.Standard/ServiceModel/Messages.cs
+++ b/src/Arc4u.Standard/ServiceModel/Messages.cs
@@ -91,7 +91,7 @@ namespace Arc4u.ServiceModel
                         property = categoryLogger.Error(lm.Text);
                         break;
                     case MessageType.Critical:
-                        property = categoryLogger.Fatal(lm.Text);
+                        property = categoryLogger.Critical(lm.Text);
                         break;
                     default:
                         property = categoryLogger.Debug(lm.Text);


### PR DESCRIPTION
This replaces the abandonned PR #98 

(1)
There is a naming anomaly in CommonMessageLogger that violates the *principle of least astonishment*:
- `LogLevel.Information` -level messages are added by methods `Information`/`LogInformation`: OK!
- `LogLevel.Warning` -level messages are added by methods `Warning`/`LogWarning`: OK!
- `LogLevel.Error` -level messages are added by methods `Error`/`LogError`: OK!

but:
- `LogLevel.Critical` -level messages are added by methods `Fatal`/`LogFatal`: ASTONISHING!

This pull request adds the expected `Critical`/`LogCritical` methods for `LogLevel.Critical`-level messages, and declares the `Fatal`/`LogFatal` as obsolete. All references to the latter in Arc4u are changed appropriately.

(2)
There is no accessible method to log `Loglevel.Trace`-level messages. The `System` method uses this log level, but it's only for internal Arc4u use. However, it is legitimate for user core to log `LogLevel-Trace`-level messages.

This pull request adds the `Trace`/`LogTrace` methods for `LogLevel-Trace`-level messages, accessible in user code.
The `System` method still exists, but contains a structured property `"Arc4u"` with value `"Internal"` to be able to disambiguate those logs messages if needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added new logging methods for Critical log level
	- Introduced Trace logging method
	- Improved logging method formatting with `CultureInfo.InvariantCulture`

- **Deprecation**
	- Marked Fatal logging methods as obsolete
	- Recommended using Critical methods instead of Fatal methods

- **Bug Fixes**
	- Updated logging method calls to use more consistent log levels

<!-- end of auto-generated comment: release notes by coderabbit.ai -->