### PR TITLE
AddContextToPrincipalMiddleware updates

### DIFF
--- a/src/Arc4u.Standard.OAuth2.AspNetCore/Middleware/AddContextToPrincipalMiddleware.cs
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore/Middleware/AddContextToPrincipalMiddleware.cs
@@ -8,7 +8,6 @@ using Arc4u.Security.Principal;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Primitives;
 
 namespace Arc4u.OAuth2.Middleware;
 public class AddContextToPrincipalMiddleware
@@ -29,26 +28,32 @@ public class AddContextToPrincipalMiddleware
     {
         ArgumentNullException.ThrowIfNull(context);
 
-        if (context.User is not null && context.User is AppPrincipal principal && principal.Identity is not null && principal.Identity.IsAuthenticated)
-        {
-            using var activity = _activitySource?.StartActivity("Add context to Arc4u Principal", ActivityKind.Producer);
+        // Note that the action of setting a traceparent and adding context to the principal are conceptually separate, but they are viewed as one "activity" for the purposes of logging.
 
-            // Ensure we have a traceparent.
+        using var activity = _activitySource?.StartActivity("Add context to Arc4u Principal", ActivityKind.Producer);
+
+        // We may have a null current activity if we are not in the context of an activity.
+        // we may not be in the context of an activity if either (1) there is no _activitySource or (2) the activity has no active listeners
+        if (Activity.Current is not null)
+        {
+            // Ensure we have a traceparent, whether we are authenticated or not, since it's always useful to have a traceparent.
             if (!context.Request.Headers.ContainsKey("traceparent"))
             {
-                // Activity.Current is not null just because we are in the context of an activity.
-                context.Request.Headers.Add("traceparent", Activity.Current!.Id);
+                // Activity.Current is not null because we are in the context of an activity.
+                context.Request.Headers.Add("traceparent", Activity.Current.Id);
             }
 
-            activity?.SetTag(LoggingConstants.ActivityId, Activity.Current!.Id);
+            activity?.SetTag(LoggingConstants.ActivityId, Activity.Current.Id);
+        }
 
-            // Check for a culture.
-            var cultureHeader = context.Request?.Headers?.FirstOrDefault(h => h.Key.Equals("culture", StringComparison.InvariantCultureIgnoreCase));
-            if (cultureHeader.HasValue && StringValues.Empty != cultureHeader.Value.Value && cultureHeader.Value.Value.Any())
+        if (context.User is not null && context.User is AppPrincipal principal && principal.Identity is not null && principal.Identity.IsAuthenticated)
+        {
+            // Check for a culture. The header dictionary takes care of the proper matching of the header name.
+            if ((context.Request?.Headers?.TryGetValue("culture", out var cultureHeader) ?? false) && cultureHeader.Any())
             {
                 try
                 {
-                    principal.Profile.CurrentCulture = new CultureInfo(cultureHeader.Value.Value[0]);
+                    principal.Profile.CurrentCulture = new CultureInfo(cultureHeader[0]);
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
This PR contains the following changes for `AddContextToPrincipalMiddleware`:

- The setting of a `traceparent` header is always useful for telemetry, independently of the fact that we are authenticated. Previously, `AddContextToPrincipalMiddleware` would only have a `traceparent` if we were authenticated. Now, `traceparent` is always present.

- `Activity.Current` can be null, because `activity` can be null if (1) `_activitySource` is null, or (2) the activity has no active listeners (source: [documentation](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.activitysource.startactivity?view=net-8.0)). The code has been modified to take this into account.

- When searching for headers, it's much more efficient to use the `IHeaderDictionary` than to use `FirstOrDefault` with a string comparator: the `IHeaderDictionary` has the correct comparison for the name built-in.


The action of setting a traceparent and adding context to the principal are conceptually separate, but they are viewed as one "activity" in this middleware: this is unexpected but is now explicitly documented.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of the `traceparent` header for improved request tracing.
	- Streamlined extraction of the culture header for better performance and readability.

- **Bug Fixes**
	- Restructured authentication status checks to clarify middleware activity creation, ensuring consistent behavior regardless of user authentication state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->