### PR TITLE
Apply packages license code according license file

### DIFF
--- a/src/Arc4u.AspNetCore.Results/Arc4u.AspNetCore.Results.csproj
+++ b/src/Arc4u.AspNetCore.Results/Arc4u.AspNetCore.Results.csproj
@@ -6,7 +6,7 @@
     <Authors>Gilles Flisch</Authors>
     <Description>Package used on Interface and Facade projects to return ProblemDetails based on Results.</Description>
     <Copyright>Gilles Flisch</Copyright>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>Apache-2.0</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>

--- a/src/Arc4u.Configuration.Store.EFCore/Arc4u.Configuration.Store.EFCore.csproj
+++ b/src/Arc4u.Configuration.Store.EFCore/Arc4u.Configuration.Store.EFCore.csproj
@@ -7,7 +7,7 @@
     <Authors>Gilles Flisch</Authors>
     <Description>Core Framework to read configuration from EfCore.</Description>
     <Copyright>Gilles Flisch</Copyright>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>Apache-2.0</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>

--- a/src/Arc4u.Prism.DI.Wpf/Arc4u.Prism.DI.Wpf.csproj
+++ b/src/Arc4u.Prism.DI.Wpf/Arc4u.Prism.DI.Wpf.csproj
@@ -26,7 +26,7 @@
     </PackageLicenseExpression>
     <PackageTags>Arc4u</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>Apache-2.0</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <LangVersion>latest</LangVersion>
     <PackageId>Arc4u.Prism.DI.Wpf</PackageId>

--- a/src/Arc4u.Standard.AspNetCore.gRpc/Arc4u.Standard.AspNetCore.gRpc.csproj
+++ b/src/Arc4u.Standard.AspNetCore.gRpc/Arc4u.Standard.AspNetCore.gRpc.csproj
@@ -7,7 +7,7 @@
     <Company>Gilles Flisch</Company>
     <Description>Core framework to integrate gRpc in asp net core.</Description>
     <Copyright>Gilles Flisch</Copyright>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>Apache-2.0</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>

--- a/src/Arc4u.Standard.Authorization/Arc4u.Standard.Authorization.csproj
+++ b/src/Arc4u.Standard.Authorization/Arc4u.Standard.Authorization.csproj
@@ -25,7 +25,7 @@
     </PackageLicenseExpression>
     <PackageTags>Arc4u</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>Apache-2.0</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <LangVersion>latest</LangVersion>
     <PackageId>Arc4u.Standard.Authorization</PackageId>

--- a/src/Arc4u.Standard.Caching.Dapr/Arc4u.Standard.Caching.Dapr.csproj
+++ b/src/Arc4u.Standard.Caching.Dapr/Arc4u.Standard.Caching.Dapr.csproj
@@ -19,7 +19,7 @@
     <PackageLicenseExpression>
     </PackageLicenseExpression>
     <Description>Core Framework used to use dapr.io state.</Description>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>Apache-2.0</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.Caching.Memory/Arc4u.Standard.Caching.Memory.csproj
+++ b/src/Arc4u.Standard.Caching.Memory/Arc4u.Standard.Caching.Memory.csproj
@@ -13,7 +13,7 @@
     <PackageLicenseExpression>
     </PackageLicenseExpression>
     <Description>Core Framework used to use memory caching.</Description>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>Apache-2.0</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.Caching.Redis/Arc4u.Standard.Caching.Redis.csproj
+++ b/src/Arc4u.Standard.Caching.Redis/Arc4u.Standard.Caching.Redis.csproj
@@ -19,7 +19,7 @@
     <PackageLicenseExpression>
     </PackageLicenseExpression>
     <Description>Core Framework used to use redis caching.</Description>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>Apache-2.0</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.Caching.Sql/Arc4u.Standard.Caching.Sql.csproj
+++ b/src/Arc4u.Standard.Caching.Sql/Arc4u.Standard.Caching.Sql.csproj
@@ -12,7 +12,7 @@
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>
     <PackageLicenseExpression>
     </PackageLicenseExpression>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>Apache-2.0</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.Caching/Arc4u.Standard.Caching.csproj
+++ b/src/Arc4u.Standard.Caching/Arc4u.Standard.Caching.csproj
@@ -18,7 +18,7 @@
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>
     <PackageLicenseExpression>
     </PackageLicenseExpression>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>Apache-2.0</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <Description>Core Framework used to use caching.</Description>
     <RepositoryType>git</RepositoryType>

--- a/src/Arc4u.Standard.Configuration.Decryptor/Arc4u.Standard.Configuration.Decryptor.csproj
+++ b/src/Arc4u.Standard.Configuration.Decryptor/Arc4u.Standard.Configuration.Decryptor.csproj
@@ -12,7 +12,7 @@
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>
     <PackageLicenseExpression>
     </PackageLicenseExpression>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>Apache-2.0</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.Configuration.Store/Arc4u.Standard.Configuration.Store.csproj
+++ b/src/Arc4u.Standard.Configuration.Store/Arc4u.Standard.Configuration.Store.csproj
@@ -7,7 +7,7 @@
     <Authors>Gilles Flisch</Authors>
     <Description>Core Framework to read configuration from EfCore.</Description>
     <Copyright>Gilles Flisch</Copyright>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>Apache-2.0</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>

--- a/src/Arc4u.Standard.Configuration/Arc4u.Standard.Configuration.csproj
+++ b/src/Arc4u.Standard.Configuration/Arc4u.Standard.Configuration.csproj
@@ -21,7 +21,7 @@
     <PackageLicenseExpression>
     </PackageLicenseExpression>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>Apache-2.0</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.Core/Arc4u.Standard.Core.csproj
+++ b/src/Arc4u.Standard.Core/Arc4u.Standard.Core.csproj
@@ -15,7 +15,7 @@
     <PackageLicenseExpression>
     </PackageLicenseExpression>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>Apache-2.0</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.Data/Arc4u.Standard.Data.csproj
+++ b/src/Arc4u.Standard.Data/Arc4u.Standard.Data.csproj
@@ -21,7 +21,7 @@
     </PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>Apache-2.0</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <Description>DataEntity core framework.</Description>
     <LangVersion>latest</LangVersion>

--- a/src/Arc4u.Standard.Dependency.ComponentModel/Arc4u.Standard.Dependency.ComponentModel.csproj
+++ b/src/Arc4u.Standard.Dependency.ComponentModel/Arc4u.Standard.Dependency.ComponentModel.csproj
@@ -13,7 +13,7 @@
     </PackageLicenseExpression>
     <RootNamespace>Arc4u.Dependency.ComponentModel</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>Apache-2.0</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.Dependency/Arc4u.Standard.Dependency.csproj
+++ b/src/Arc4u.Standard.Dependency/Arc4u.Standard.Dependency.csproj
@@ -19,7 +19,7 @@
     <PackageLicenseExpression>
     </PackageLicenseExpression>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>Apache-2.0</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.Diagnostics.Serilog.Sinks.RealmDb/Arc4u.Standard.Diagnostics.Serilog.Sinks.RealmDb.csproj
+++ b/src/Arc4u.Standard.Diagnostics.Serilog.Sinks.RealmDb/Arc4u.Standard.Diagnostics.Serilog.Sinks.RealmDb.csproj
@@ -19,7 +19,7 @@
     <PackageLicenseExpression>
     </PackageLicenseExpression>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>Apache-2.0</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.Diagnostics.Serilog/Arc4u.Standard.Diagnostics.Serilog.csproj
+++ b/src/Arc4u.Standard.Diagnostics.Serilog/Arc4u.Standard.Diagnostics.Serilog.csproj
@@ -21,7 +21,7 @@
     <PackageLicenseExpression>
     </PackageLicenseExpression>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>Apache-2.0</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.Diagnostics.TraceListeners/Arc4u.Standard.Diagnostics.TraceListeners.csproj
+++ b/src/Arc4u.Standard.Diagnostics.TraceListeners/Arc4u.Standard.Diagnostics.TraceListeners.csproj
@@ -19,7 +19,7 @@
     <PackageLicenseExpression>
     </PackageLicenseExpression>
     <Description>Core Tracelisteners Diagnostics Framework used to log information via Tracing.</Description>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>Apache-2.0</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.Diagnostics/Arc4u.Standard.Diagnostics.csproj
+++ b/src/Arc4u.Standard.Diagnostics/Arc4u.Standard.Diagnostics.csproj
@@ -20,7 +20,7 @@
     </PackageLicenseExpression>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Core Diagnostics Framework used to build application.</Description>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>Apache-2.0</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.Dispatcher/Arc4u.Standard.Dispatcher.csproj
+++ b/src/Arc4u.Standard.Dispatcher/Arc4u.Standard.Dispatcher.csproj
@@ -25,7 +25,7 @@
     </PackageLicenseExpression>
     <PackageTags>Arc4u</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>Apache-2.0</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <LangVersion>latest</LangVersion>
     <PackageId>Arc4u.Standard.Dispatcher</PackageId>

--- a/src/Arc4u.Standard.EfCore/Arc4u.Standard.EfCore.csproj
+++ b/src/Arc4u.Standard.EfCore/Arc4u.Standard.EfCore.csproj
@@ -5,7 +5,7 @@
     <Authors>Gilles Flisch</Authors>
     <Description>Core Framework to use EfCore.</Description>
     <Copyright>Gilles Flisch</Copyright>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>Apache-2.0</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>

--- a/src/Arc4u.Standard.FluentResults/Arc4u.Standard.FluentResults.csproj
+++ b/src/Arc4u.Standard.FluentResults/Arc4u.Standard.FluentResults.csproj
@@ -11,7 +11,7 @@
     <Company>Gilles Flisch</Company>
     <Description>FLuentResult with fluent validators dedicated for Arc4u.</Description>
     <Copyright>Gilles Flisch</Copyright>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>Apache-2.0</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/src/Arc4u.Standard.FluentValidation/Arc4u.Standard.FluentValidation.csproj
+++ b/src/Arc4u.Standard.FluentValidation/Arc4u.Standard.FluentValidation.csproj
@@ -8,7 +8,7 @@
     <Company>Gilles Flisch</Company>
     <Description>FluentValidation validators dedicated for Arc4u.</Description>
     <Copyright>Gilles Flisch</Copyright>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>Apache-2.0</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>

--- a/src/Arc4u.Standard.MongoDB/Arc4u.Standard.MongoDB.csproj
+++ b/src/Arc4u.Standard.MongoDB/Arc4u.Standard.MongoDB.csproj
@@ -5,7 +5,7 @@
     <Authors>Gilles Flisch</Authors>
     <Description>Core Framework to use MongoDB.</Description>
     <Copyright>Gilles Flisch</Copyright>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>Apache-2.0</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>

--- a/src/Arc4u.Standard.NServiceBus.Core/Arc4u.Standard.NServiceBus.Core.csproj
+++ b/src/Arc4u.Standard.NServiceBus.Core/Arc4u.Standard.NServiceBus.Core.csproj
@@ -16,7 +16,7 @@
     </PackageLicenseExpression>
     <PackageTags>Arc4u</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>Apache-2.0</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <LangVersion>latest</LangVersion>
     <PackageId>Arc4u.Standard.NServiceBus.Core</PackageId>

--- a/src/Arc4u.Standard.NServiceBus.RabbitMQ/Arc4u.Standard.NServiceBus.RabbitMQ.csproj
+++ b/src/Arc4u.Standard.NServiceBus.RabbitMQ/Arc4u.Standard.NServiceBus.RabbitMQ.csproj
@@ -18,7 +18,7 @@
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>
     <PackageLicenseExpression>
     </PackageLicenseExpression>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>Apache-2.0</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.NServiceBus/Arc4u.Standard.NServiceBus.csproj
+++ b/src/Arc4u.Standard.NServiceBus/Arc4u.Standard.NServiceBus.csproj
@@ -19,7 +19,7 @@
     <PackageLicenseExpression>
     </PackageLicenseExpression>
     <Description>Core Framework used to connect application with NServiceBus.</Description>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>Apache-2.0</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.OAuth.Msal/Arc4u - Backup.Standard.OAuth2.Msal.csproj
+++ b/src/Arc4u.Standard.OAuth.Msal/Arc4u - Backup.Standard.OAuth2.Msal.csproj
@@ -20,7 +20,7 @@
     <PackageLicenseExpression>
     </PackageLicenseExpression>
     <Description>Core Framework used to connect application with OAuth2 and Msal.</Description>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>Apache-2.0</PackageLicenseFile>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>
     <PackageId>Arc4u.Standard.OAuth2.Msal</PackageId>

--- a/src/Arc4u.Standard.OAuth.Msal/Arc4u.Standard.OAuth2.Msal.csproj
+++ b/src/Arc4u.Standard.OAuth.Msal/Arc4u.Standard.OAuth2.Msal.csproj
@@ -20,7 +20,7 @@
     <PackageLicenseExpression>
     </PackageLicenseExpression>
     <Description>Core Framework used to connect application with OAuth2 and Msal.</Description>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>Apache-2.0</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.OAuth2.AspNetCore.Adal/Arc4u.Standard.OAuth2.AspNetCore.Adal.csproj
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore.Adal/Arc4u.Standard.OAuth2.AspNetCore.Adal.csproj
@@ -15,7 +15,7 @@
     </PackageLicenseExpression>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Core Framework used to connect application with OAuth2 with Adal.</Description>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>Apache-2.0</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.OAuth2.AspNetCore.Api/Arc4u.Standard.OAuth2.AspNetCore.Api.csproj
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore.Api/Arc4u.Standard.OAuth2.AspNetCore.Api.csproj
@@ -5,7 +5,7 @@
     <Authors>Gilles Flisch</Authors>
     <Description>Package used on Interface and Facade projects</Description>
     <Copyright>Gilles Flisch</Copyright>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>Apache-2.0</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>

--- a/src/Arc4u.Standard.OAuth2.AspNetCore.Authentication/Arc4u.Standard.OAuth2.AspNetCore.Authentication.csproj
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore.Authentication/Arc4u.Standard.OAuth2.AspNetCore.Authentication.csproj
@@ -14,7 +14,7 @@
     <Company>Gilles Flisch</Company>
     <Description>Core framework to integrate OAuth2 and OpenIdConnect in a service.</Description>
     <Copyright>Gilles Flisch</Copyright>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>Apache-2.0</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>

--- a/src/Arc4u.Standard.OAuth2.AspNetCore.Blazor/Arc4u.Standard.OAuth2.AspNetCore.Blazor.csproj
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore.Blazor/Arc4u.Standard.OAuth2.AspNetCore.Blazor.csproj
@@ -5,7 +5,7 @@
     <Authors>Gilles Flisch</Authors>
     <Description>Package used on FaÃ§ade projects to add OpenId endpoint to Blazor projects.</Description>
     <Copyright>Gilles Flisch</Copyright>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>Apache-2.0</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>

--- a/src/Arc4u.Standard.OAuth2.AspNetCore/Arc4u.Standard.OAuth2.AspNetCore.csproj
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore/Arc4u.Standard.OAuth2.AspNetCore.csproj
@@ -7,7 +7,7 @@
     <Company>Gilles Flisch</Company>
     <Description>Core framework to integrate OAuth2 and creation of the principal in asp net core.</Description>
     <Copyright>Gilles Flisch</Copyright>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>Apache-2.0</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>

--- a/src/Arc4u.Standard.OAuth2.Blazor/Arc4u.Standard.OAuth2.Blazor.csproj
+++ b/src/Arc4u.Standard.OAuth2.Blazor/Arc4u.Standard.OAuth2.Blazor.csproj
@@ -8,7 +8,7 @@
     <Company>Gilles Flisch</Company>
     <Description>OAuth2 scenario for Blazor.</Description>
     <Copyright>Gilles Flisch</Copyright>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>Apache-2.0</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>

--- a/src/Arc4u.Standard.OAuth2.Client/Arc4u.Standard.OAuth2.Client.csproj
+++ b/src/Arc4u.Standard.OAuth2.Client/Arc4u.Standard.OAuth2.Client.csproj
@@ -20,7 +20,7 @@
     <PackageLicenseExpression>
     </PackageLicenseExpression>
     <Description>Core Framework used to connect application with OAuth2.</Description>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>Apache-2.0</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.OAuth2/Arc4u.Standard.OAuth2.csproj
+++ b/src/Arc4u.Standard.OAuth2/Arc4u.Standard.OAuth2.csproj
@@ -18,7 +18,7 @@
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>
     <PackageLicenseExpression>
     </PackageLicenseExpression>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>Apache-2.0</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.OData/Arc4u.Standard.OData.csproj
+++ b/src/Arc4u.Standard.OData/Arc4u.Standard.OData.csproj
@@ -20,7 +20,7 @@
     <PackageLicenseExpression>
     </PackageLicenseExpression>
     <Description>OData extensions.</Description>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>Apache-2.0</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.Results/Arc4u.Standard.Results.csproj
+++ b/src/Arc4u.Standard.Results/Arc4u.Standard.Results.csproj
@@ -11,7 +11,7 @@
     <Company>Gilles Flisch</Company>
     <Description>FLuentResult with fluent validators dedicated for Arc4u.</Description>
     <Copyright>Gilles Flisch</Copyright>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>Apache-2.0</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>

--- a/src/Arc4u.Standard.Serializer.JSon/Arc4u.Standard.Serializer.JSon.csproj
+++ b/src/Arc4u.Standard.Serializer.JSon/Arc4u.Standard.Serializer.JSon.csproj
@@ -13,7 +13,7 @@
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>
     <PackageLicenseExpression>
     </PackageLicenseExpression>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>Apache-2.0</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.Serializer.Protobuf/Arc4u.Standard.Serializer.Protobuf.csproj
+++ b/src/Arc4u.Standard.Serializer.Protobuf/Arc4u.Standard.Serializer.Protobuf.csproj
@@ -13,7 +13,7 @@
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>
     <PackageLicenseExpression>
     </PackageLicenseExpression>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>Apache-2.0</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.Serializer.ProtobufV2/Arc4u.Standard.Serializer.ProtobufV2.csproj
+++ b/src/Arc4u.Standard.Serializer.ProtobufV2/Arc4u.Standard.Serializer.ProtobufV2.csproj
@@ -13,7 +13,7 @@
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>
     <PackageLicenseExpression>
     </PackageLicenseExpression>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>Apache-2.0</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.Serializer/Arc4u.Standard.Serializer.csproj
+++ b/src/Arc4u.Standard.Serializer/Arc4u.Standard.Serializer.csproj
@@ -15,7 +15,7 @@
     </PackageLicenseExpression>
     <Authors>Gilles Flisch</Authors>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>Apache-2.0</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.Threading/Arc4u.Standard.Threading.csproj
+++ b/src/Arc4u.Standard.Threading/Arc4u.Standard.Threading.csproj
@@ -20,7 +20,7 @@
     </PackageLicenseExpression>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Core threading Framework used to build application.</Description>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>Apache-2.0</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.gRPC/Arc4u.Standard.gRPC.csproj
+++ b/src/Arc4u.Standard.gRPC/Arc4u.Standard.gRPC.csproj
@@ -5,7 +5,7 @@
     <Authors>Gilles Flisch</Authors>
     <Description>Core Framework to use gRPC.</Description>
     <Copyright>Gilles Flisch</Copyright>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>Apache-2.0</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>

--- a/src/Arc4u.Standard/Arc4u.Standard.csproj
+++ b/src/Arc4u.Standard/Arc4u.Standard.csproj
@@ -22,7 +22,7 @@
     </PackageLicenseExpression>
     <PackageTags>Arc4u</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>Apache-2.0</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <LangVersion>latest</LangVersion>
     <PackageId>Arc4u.Standard</PackageId>


### PR DESCRIPTION
Exchanged license string "LICENSE" by official Apache 2.0 SPDX license code to enable package management systems to display the license, w/o the need to parse any LICENSE file.

Related issue: #115

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated licensing information across multiple project files from `LICENSE` to `Apache-2.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->