### PR TITLE
Apply packages license code according license file

### DIFF
--- a/src/Arc4u.AspNetCore.Results/Arc4u.AspNetCore.Results.csproj
+++ b/src/Arc4u.AspNetCore.Results/Arc4u.AspNetCore.Results.csproj
@@ -6,10 +6,10 @@
     <Authors>Gilles Flisch</Authors>
     <Description>Package used on Interface and Facade projects to return ProblemDetails based on Results.</Description>
     <Copyright>Gilles Flisch</Copyright>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>

--- a/src/Arc4u.Configuration.Store.EFCore/Arc4u.Configuration.Store.EFCore.csproj
+++ b/src/Arc4u.Configuration.Store.EFCore/Arc4u.Configuration.Store.EFCore.csproj
@@ -7,7 +7,7 @@
     <Authors>Gilles Flisch</Authors>
     <Description>Core Framework to read configuration from EfCore.</Description>
     <Copyright>Gilles Flisch</Copyright>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageIcon>Arc4u.png</PackageIcon>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>

--- a/src/Arc4u.Prism.DI.Wpf/Arc4u.Prism.DI.Wpf.csproj
+++ b/src/Arc4u.Prism.DI.Wpf/Arc4u.Prism.DI.Wpf.csproj
@@ -22,11 +22,9 @@
     <Copyright>Gilles Flisch</Copyright>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>
-    <PackageLicenseExpression>
-    </PackageLicenseExpression>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageTags>Arc4u</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <LangVersion>latest</LangVersion>
     <PackageId>Arc4u.Prism.DI.Wpf</PackageId>

--- a/src/Arc4u.Standard.AspNetCore.gRpc/Arc4u.Standard.AspNetCore.gRpc.csproj
+++ b/src/Arc4u.Standard.AspNetCore.gRpc/Arc4u.Standard.AspNetCore.gRpc.csproj
@@ -7,7 +7,7 @@
     <Company>Gilles Flisch</Company>
     <Description>Core framework to integrate gRpc in asp net core.</Description>
     <Copyright>Gilles Flisch</Copyright>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageIcon>Arc4u.png</PackageIcon>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>

--- a/src/Arc4u.Standard.Authorization/Arc4u.Standard.Authorization.csproj
+++ b/src/Arc4u.Standard.Authorization/Arc4u.Standard.Authorization.csproj
@@ -21,11 +21,9 @@
     <Copyright>Gilles Flisch</Copyright>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>
-    <PackageLicenseExpression>
-    </PackageLicenseExpression>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageTags>Arc4u</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <LangVersion>latest</LangVersion>
     <PackageId>Arc4u.Standard.Authorization</PackageId>

--- a/src/Arc4u.Standard.Caching.Dapr/Arc4u.Standard.Caching.Dapr.csproj
+++ b/src/Arc4u.Standard.Caching.Dapr/Arc4u.Standard.Caching.Dapr.csproj
@@ -16,10 +16,8 @@
     <Copyright>Gilles Flisch</Copyright>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>
-    <PackageLicenseExpression>
-    </PackageLicenseExpression>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Description>Core Framework used to use dapr.io state.</Description>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.Caching.Memory/Arc4u.Standard.Caching.Memory.csproj
+++ b/src/Arc4u.Standard.Caching.Memory/Arc4u.Standard.Caching.Memory.csproj
@@ -10,10 +10,8 @@
     <Copyright>Gilles Flisch</Copyright>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>
-    <PackageLicenseExpression>
-    </PackageLicenseExpression>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Description>Core Framework used to use memory caching.</Description>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.Caching.Redis/Arc4u.Standard.Caching.Redis.csproj
+++ b/src/Arc4u.Standard.Caching.Redis/Arc4u.Standard.Caching.Redis.csproj
@@ -16,10 +16,8 @@
     <Copyright>Gilles Flisch</Copyright>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>
-    <PackageLicenseExpression>
-    </PackageLicenseExpression>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Description>Core Framework used to use redis caching.</Description>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.Caching.Sql/Arc4u.Standard.Caching.Sql.csproj
+++ b/src/Arc4u.Standard.Caching.Sql/Arc4u.Standard.Caching.Sql.csproj
@@ -10,9 +10,7 @@
     <Copyright>Gilles Flisch</Copyright>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>
-    <PackageLicenseExpression>
-    </PackageLicenseExpression>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.Caching/Arc4u.Standard.Caching.csproj
+++ b/src/Arc4u.Standard.Caching/Arc4u.Standard.Caching.csproj
@@ -16,9 +16,7 @@
     <Copyright>Gilles Flisch</Copyright>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>
-    <PackageLicenseExpression>
-    </PackageLicenseExpression>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageIcon>Arc4u.png</PackageIcon>
     <Description>Core Framework used to use caching.</Description>
     <RepositoryType>git</RepositoryType>

--- a/src/Arc4u.Standard.Configuration.Decryptor/Arc4u.Standard.Configuration.Decryptor.csproj
+++ b/src/Arc4u.Standard.Configuration.Decryptor/Arc4u.Standard.Configuration.Decryptor.csproj
@@ -10,9 +10,7 @@
     <Copyright>Gilles Flisch</Copyright>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>
-    <PackageLicenseExpression>
-    </PackageLicenseExpression>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.Configuration.Store/Arc4u.Standard.Configuration.Store.csproj
+++ b/src/Arc4u.Standard.Configuration.Store/Arc4u.Standard.Configuration.Store.csproj
@@ -7,7 +7,7 @@
     <Authors>Gilles Flisch</Authors>
     <Description>Core Framework to read configuration from EfCore.</Description>
     <Copyright>Gilles Flisch</Copyright>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageIcon>Arc4u.png</PackageIcon>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>

--- a/src/Arc4u.Standard.Configuration/Arc4u.Standard.Configuration.csproj
+++ b/src/Arc4u.Standard.Configuration/Arc4u.Standard.Configuration.csproj
@@ -18,10 +18,8 @@
     <Copyright>Gilles Flisch</Copyright>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>
-    <PackageLicenseExpression>
-    </PackageLicenseExpression>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.Core/Arc4u.Standard.Core.csproj
+++ b/src/Arc4u.Standard.Core/Arc4u.Standard.Core.csproj
@@ -12,10 +12,8 @@
     <Copyright>Gilles Flisch</Copyright>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>
-    <PackageLicenseExpression>
-    </PackageLicenseExpression>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.Data/Arc4u.Standard.Data.csproj
+++ b/src/Arc4u.Standard.Data/Arc4u.Standard.Data.csproj
@@ -17,11 +17,9 @@
     <Copyright>Gilles Flisch</Copyright>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>
-    <PackageLicenseExpression>
-    </PackageLicenseExpression>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <Description>DataEntity core framework.</Description>
     <LangVersion>latest</LangVersion>

--- a/src/Arc4u.Standard.Dependency.ComponentModel/Arc4u.Standard.Dependency.ComponentModel.csproj
+++ b/src/Arc4u.Standard.Dependency.ComponentModel/Arc4u.Standard.Dependency.ComponentModel.csproj
@@ -9,11 +9,9 @@
     <Copyright>Gilles Flisch</Copyright>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>
-    <PackageLicenseExpression>
-    </PackageLicenseExpression>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <RootNamespace>Arc4u.Dependency.ComponentModel</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.Dependency/Arc4u.Standard.Dependency.csproj
+++ b/src/Arc4u.Standard.Dependency/Arc4u.Standard.Dependency.csproj
@@ -16,10 +16,8 @@
     <Copyright>Gilles Flisch</Copyright>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>
-    <PackageLicenseExpression>
-    </PackageLicenseExpression>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.Diagnostics.Serilog.Sinks.RealmDb/Arc4u.Standard.Diagnostics.Serilog.Sinks.RealmDb.csproj
+++ b/src/Arc4u.Standard.Diagnostics.Serilog.Sinks.RealmDb/Arc4u.Standard.Diagnostics.Serilog.Sinks.RealmDb.csproj
@@ -16,10 +16,8 @@
     <Copyright>Gilles Flisch</Copyright>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>
-    <PackageLicenseExpression>
-    </PackageLicenseExpression>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.Diagnostics.Serilog/Arc4u.Standard.Diagnostics.Serilog.csproj
+++ b/src/Arc4u.Standard.Diagnostics.Serilog/Arc4u.Standard.Diagnostics.Serilog.csproj
@@ -18,10 +18,8 @@
     <Copyright>Gilles Flisch</Copyright>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>
-    <PackageLicenseExpression>
-    </PackageLicenseExpression>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.Diagnostics.TraceListeners/Arc4u.Standard.Diagnostics.TraceListeners.csproj
+++ b/src/Arc4u.Standard.Diagnostics.TraceListeners/Arc4u.Standard.Diagnostics.TraceListeners.csproj
@@ -16,10 +16,8 @@
     <Copyright>Gilles Flisch</Copyright>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>
-    <PackageLicenseExpression>
-    </PackageLicenseExpression>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Description>Core Tracelisteners Diagnostics Framework used to log information via Tracing.</Description>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.Diagnostics/Arc4u.Standard.Diagnostics.csproj
+++ b/src/Arc4u.Standard.Diagnostics/Arc4u.Standard.Diagnostics.csproj
@@ -16,11 +16,9 @@
     <Copyright>Gilles Flisch</Copyright>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>
-    <PackageLicenseExpression>
-    </PackageLicenseExpression>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Core Diagnostics Framework used to build application.</Description>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.Dispatcher/Arc4u.Standard.Dispatcher.csproj
+++ b/src/Arc4u.Standard.Dispatcher/Arc4u.Standard.Dispatcher.csproj
@@ -21,11 +21,9 @@
     <Copyright>Gilles Flisch</Copyright>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>
-    <PackageLicenseExpression>
-    </PackageLicenseExpression>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageTags>Arc4u</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <LangVersion>latest</LangVersion>
     <PackageId>Arc4u.Standard.Dispatcher</PackageId>

--- a/src/Arc4u.Standard.EfCore/Arc4u.Standard.EfCore.csproj
+++ b/src/Arc4u.Standard.EfCore/Arc4u.Standard.EfCore.csproj
@@ -5,7 +5,7 @@
     <Authors>Gilles Flisch</Authors>
     <Description>Core Framework to use EfCore.</Description>
     <Copyright>Gilles Flisch</Copyright>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageIcon>Arc4u.png</PackageIcon>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>

--- a/src/Arc4u.Standard.FluentResults/Arc4u.Standard.FluentResults.csproj
+++ b/src/Arc4u.Standard.FluentResults/Arc4u.Standard.FluentResults.csproj
@@ -11,7 +11,7 @@
     <Company>Gilles Flisch</Company>
     <Description>FLuentResult with fluent validators dedicated for Arc4u.</Description>
     <Copyright>Gilles Flisch</Copyright>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/src/Arc4u.Standard.FluentValidation/Arc4u.Standard.FluentValidation.csproj
+++ b/src/Arc4u.Standard.FluentValidation/Arc4u.Standard.FluentValidation.csproj
@@ -8,7 +8,7 @@
     <Company>Gilles Flisch</Company>
     <Description>FluentValidation validators dedicated for Arc4u.</Description>
     <Copyright>Gilles Flisch</Copyright>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageIcon>Arc4u.png</PackageIcon>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>

--- a/src/Arc4u.Standard.MongoDB/Arc4u.Standard.MongoDB.csproj
+++ b/src/Arc4u.Standard.MongoDB/Arc4u.Standard.MongoDB.csproj
@@ -5,7 +5,7 @@
     <Authors>Gilles Flisch</Authors>
     <Description>Core Framework to use MongoDB.</Description>
     <Copyright>Gilles Flisch</Copyright>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageIcon>Arc4u.png</PackageIcon>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>

--- a/src/Arc4u.Standard.NServiceBus.Core/Arc4u.Standard.NServiceBus.Core.csproj
+++ b/src/Arc4u.Standard.NServiceBus.Core/Arc4u.Standard.NServiceBus.Core.csproj
@@ -12,11 +12,9 @@
     <Copyright>Gilles Flisch</Copyright>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>
-    <PackageLicenseExpression>
-    </PackageLicenseExpression>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageTags>Arc4u</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <LangVersion>latest</LangVersion>
     <PackageId>Arc4u.Standard.NServiceBus.Core</PackageId>

--- a/src/Arc4u.Standard.NServiceBus.RabbitMQ/Arc4u.Standard.NServiceBus.RabbitMQ.csproj
+++ b/src/Arc4u.Standard.NServiceBus.RabbitMQ/Arc4u.Standard.NServiceBus.RabbitMQ.csproj
@@ -16,9 +16,7 @@
     <Copyright>Gilles Flisch</Copyright>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>
-    <PackageLicenseExpression>
-    </PackageLicenseExpression>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.NServiceBus/Arc4u.Standard.NServiceBus.csproj
+++ b/src/Arc4u.Standard.NServiceBus/Arc4u.Standard.NServiceBus.csproj
@@ -16,10 +16,8 @@
     <Copyright>Gilles Flisch</Copyright>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>
-    <PackageLicenseExpression>
-    </PackageLicenseExpression>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Description>Core Framework used to connect application with NServiceBus.</Description>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.OAuth.Msal/Arc4u - Backup.Standard.OAuth2.Msal.csproj
+++ b/src/Arc4u.Standard.OAuth.Msal/Arc4u - Backup.Standard.OAuth2.Msal.csproj
@@ -17,10 +17,8 @@
     <Copyright>Gilles Flisch</Copyright>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>
-    <PackageLicenseExpression>
-    </PackageLicenseExpression>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Description>Core Framework used to connect application with OAuth2 and Msal.</Description>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>
     <PackageId>Arc4u.Standard.OAuth2.Msal</PackageId>

--- a/src/Arc4u.Standard.OAuth.Msal/Arc4u.Standard.OAuth2.Msal.csproj
+++ b/src/Arc4u.Standard.OAuth.Msal/Arc4u.Standard.OAuth2.Msal.csproj
@@ -17,10 +17,8 @@
     <Copyright>Gilles Flisch</Copyright>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>
-    <PackageLicenseExpression>
-    </PackageLicenseExpression>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Description>Core Framework used to connect application with OAuth2 and Msal.</Description>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.OAuth2.AspNetCore.Adal/Arc4u.Standard.OAuth2.AspNetCore.Adal.csproj
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore.Adal/Arc4u.Standard.OAuth2.AspNetCore.Adal.csproj
@@ -11,11 +11,9 @@
     <Copyright>Gilles Flisch</Copyright>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>
-    <PackageLicenseExpression>
-    </PackageLicenseExpression>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Core Framework used to connect application with OAuth2 with Adal.</Description>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.OAuth2.AspNetCore.Api/Arc4u.Standard.OAuth2.AspNetCore.Api.csproj
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore.Api/Arc4u.Standard.OAuth2.AspNetCore.Api.csproj
@@ -5,7 +5,7 @@
     <Authors>Gilles Flisch</Authors>
     <Description>Package used on Interface and Facade projects</Description>
     <Copyright>Gilles Flisch</Copyright>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageIcon>Arc4u.png</PackageIcon>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>

--- a/src/Arc4u.Standard.OAuth2.AspNetCore.Authentication/Arc4u.Standard.OAuth2.AspNetCore.Authentication.csproj
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore.Authentication/Arc4u.Standard.OAuth2.AspNetCore.Authentication.csproj
@@ -14,7 +14,7 @@
     <Company>Gilles Flisch</Company>
     <Description>Core framework to integrate OAuth2 and OpenIdConnect in a service.</Description>
     <Copyright>Gilles Flisch</Copyright>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageIcon>Arc4u.png</PackageIcon>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>

--- a/src/Arc4u.Standard.OAuth2.AspNetCore.Blazor/Arc4u.Standard.OAuth2.AspNetCore.Blazor.csproj
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore.Blazor/Arc4u.Standard.OAuth2.AspNetCore.Blazor.csproj
@@ -5,7 +5,7 @@
     <Authors>Gilles Flisch</Authors>
     <Description>Package used on FaÃ§ade projects to add OpenId endpoint to Blazor projects.</Description>
     <Copyright>Gilles Flisch</Copyright>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageIcon>Arc4u.png</PackageIcon>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>

--- a/src/Arc4u.Standard.OAuth2.AspNetCore/Arc4u.Standard.OAuth2.AspNetCore.csproj
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore/Arc4u.Standard.OAuth2.AspNetCore.csproj
@@ -7,7 +7,7 @@
     <Company>Gilles Flisch</Company>
     <Description>Core framework to integrate OAuth2 and creation of the principal in asp net core.</Description>
     <Copyright>Gilles Flisch</Copyright>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageIcon>Arc4u.png</PackageIcon>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>

--- a/src/Arc4u.Standard.OAuth2.Blazor/Arc4u.Standard.OAuth2.Blazor.csproj
+++ b/src/Arc4u.Standard.OAuth2.Blazor/Arc4u.Standard.OAuth2.Blazor.csproj
@@ -8,7 +8,7 @@
     <Company>Gilles Flisch</Company>
     <Description>OAuth2 scenario for Blazor.</Description>
     <Copyright>Gilles Flisch</Copyright>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageIcon>Arc4u.png</PackageIcon>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>

--- a/src/Arc4u.Standard.OAuth2.Client/Arc4u.Standard.OAuth2.Client.csproj
+++ b/src/Arc4u.Standard.OAuth2.Client/Arc4u.Standard.OAuth2.Client.csproj
@@ -17,10 +17,8 @@
     <Copyright>Gilles Flisch</Copyright>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>
-    <PackageLicenseExpression>
-    </PackageLicenseExpression>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Description>Core Framework used to connect application with OAuth2.</Description>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.OAuth2/Arc4u.Standard.OAuth2.csproj
+++ b/src/Arc4u.Standard.OAuth2/Arc4u.Standard.OAuth2.csproj
@@ -16,9 +16,7 @@
     <Copyright>Gilles Flisch</Copyright>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>
-    <PackageLicenseExpression>
-    </PackageLicenseExpression>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.OData/Arc4u.Standard.OData.csproj
+++ b/src/Arc4u.Standard.OData/Arc4u.Standard.OData.csproj
@@ -17,10 +17,8 @@
     <Copyright>Gilles Flisch</Copyright>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>
-    <PackageLicenseExpression>
-    </PackageLicenseExpression>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Description>OData extensions.</Description>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.Results/Arc4u.Standard.Results.csproj
+++ b/src/Arc4u.Standard.Results/Arc4u.Standard.Results.csproj
@@ -11,7 +11,7 @@
     <Company>Gilles Flisch</Company>
     <Description>FLuentResult with fluent validators dedicated for Arc4u.</Description>
     <Copyright>Gilles Flisch</Copyright>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageIcon>Arc4u.png</PackageIcon>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>

--- a/src/Arc4u.Standard.Serializer.JSon/Arc4u.Standard.Serializer.JSon.csproj
+++ b/src/Arc4u.Standard.Serializer.JSon/Arc4u.Standard.Serializer.JSon.csproj
@@ -11,9 +11,7 @@
     <Copyright>Gilles Flisch</Copyright>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>
-    <PackageLicenseExpression>
-    </PackageLicenseExpression>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.Serializer.Protobuf/Arc4u.Standard.Serializer.Protobuf.csproj
+++ b/src/Arc4u.Standard.Serializer.Protobuf/Arc4u.Standard.Serializer.Protobuf.csproj
@@ -11,9 +11,7 @@
     <Copyright>Gilles Flisch</Copyright>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>
-    <PackageLicenseExpression>
-    </PackageLicenseExpression>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.Serializer.ProtobufV2/Arc4u.Standard.Serializer.ProtobufV2.csproj
+++ b/src/Arc4u.Standard.Serializer.ProtobufV2/Arc4u.Standard.Serializer.ProtobufV2.csproj
@@ -11,9 +11,7 @@
     <Copyright>Gilles Flisch</Copyright>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>
-    <PackageLicenseExpression>
-    </PackageLicenseExpression>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.Serializer/Arc4u.Standard.Serializer.csproj
+++ b/src/Arc4u.Standard.Serializer/Arc4u.Standard.Serializer.csproj
@@ -11,11 +11,9 @@
     <Copyright>Gilles Flisch</Copyright>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>
-    <PackageLicenseExpression>
-    </PackageLicenseExpression>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Authors>Gilles Flisch</Authors>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.Threading/Arc4u.Standard.Threading.csproj
+++ b/src/Arc4u.Standard.Threading/Arc4u.Standard.Threading.csproj
@@ -16,11 +16,9 @@
     <Copyright>Gilles Flisch</Copyright>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>
-    <PackageLicenseExpression>
-    </PackageLicenseExpression>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Core threading Framework used to build application.</Description>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Arc4u</PackageTags>

--- a/src/Arc4u.Standard.gRPC/Arc4u.Standard.gRPC.csproj
+++ b/src/Arc4u.Standard.gRPC/Arc4u.Standard.gRPC.csproj
@@ -5,7 +5,7 @@
     <Authors>Gilles Flisch</Authors>
     <Description>Core Framework to use gRPC.</Description>
     <Copyright>Gilles Flisch</Copyright>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageIcon>Arc4u.png</PackageIcon>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>

--- a/src/Arc4u.Standard/Arc4u.Standard.csproj
+++ b/src/Arc4u.Standard/Arc4u.Standard.csproj
@@ -18,11 +18,9 @@
     <Copyright>Gilles Flisch</Copyright>
     <PackageProjectUrl>https://github.com/GFlisch/Arc4u</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GFlisch/Arc4u</RepositoryUrl>
-    <PackageLicenseExpression>
-    </PackageLicenseExpression>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageTags>Arc4u</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageIcon>Arc4u.png</PackageIcon>
     <LangVersion>latest</LangVersion>
     <PackageId>Arc4u.Standard</PackageId>


### PR DESCRIPTION
Exchanged license string "LICENSE" by official Apache 2.0 SPDX license code to enable package management systems to display the license, w/o the need to parse any LICENSE file.

Because it's not possible to use a license code and a license file in parallel, the license file reference was removed from package generation. Furthermore, a license file should be linked only, if the package is not an OSI and FSF approved license.
As all Arc4u packages use license Apache 2.0 - which is a OSI and FSF approved license there should not be any issue.

Related issue: #115

---

### Remark

Unfortunately I'm not sure which target branch might be the correct one, so I point to `master`. Please let me know to which I have to request the merge or just change this by your own (if possible).

I tested the build and creation of all NuGet packages. In addition I checked in the VS NuGet package manager the displayed license. Both worked w/o any issues on my end, so packages were created and I saw license "Apache-2.0" what is the by OSI and FSF approved license code.

All further information is already given in #115.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated license information across all project files to `Apache-2.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->