### PR TITLE
Eliminate token cache timeout setting in most cases

### DIFF
--- a/src/Arc4u.Standard.OAuth2.AspNetCore.Adal/Token/Cache.cs
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore.Adal/Token/Cache.cs
@@ -1,9 +1,7 @@
-﻿using Arc4u.Dependency;
+using Arc4u.Dependency;
 using Arc4u.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.Clients.ActiveDirectory;
-using System;
-using System.Collections.Generic;
 
 namespace Arc4u.OAuth2.Token.Adal
 {
@@ -75,7 +73,16 @@ namespace Arc4u.OAuth2.Token.Adal
             if (HasStateChanged)
             {
                 Logger.Technical().From<Cache>().System($"Adding token information to the cache for the identifier: {_identifier}.").Log();
-                TokenCache.Put(_identifier, SerializeAdalV3());
+                var now = DateTimeOffset.UtcNow;
+                var maxExpires = now;
+                foreach (var tokenCacheItem in ReadItems())
+                {
+                    if (tokenCacheItem.ExpiresOn > maxExpires)
+                    {
+                        maxExpires = tokenCacheItem.ExpiresOn;
+                    }
+                }
+                TokenCache.Put(_identifier, maxExpires - now, SerializeAdalV3());
                 Logger.Technical().From<Cache>().System($"Added token information to the cache for the identifier: {_identifier}.").Log();
 
                 HasStateChanged = false;

--- a/src/Arc4u.Standard.OAuth2.AspNetCore/Extensions/AddClaimsFillerExtension.cs
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore/Extensions/AddClaimsFillerExtension.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Linq;
 using Arc4u.Configuration;
 using Arc4u.OAuth2.Options;
 using Microsoft.Extensions.Configuration;
@@ -13,9 +11,21 @@ public static class AddClaimsFillerExtension
         var validate = new ClaimsFillerOptions();
         options(validate);
 
-        if (validate.LoadClaimsFromClaimsFillerProvider && (null == validate.SettingsKeys || !validate.SettingsKeys.Any()))
+        if (validate.LoadClaimsFromClaimsFillerProvider)
         {
-            throw new ConfigurationException("Settings key must be provided.");
+            string? configErrors = null;
+            if (null == validate.SettingsKeys || !validate.SettingsKeys.Any())
+            {
+                configErrors += "Settings key must be provided." + System.Environment.NewLine;
+            }
+            if (validate.LoadClaimsFromClaimsFillerProvider && validate.MaxTime == TimeSpan.Zero)
+            {
+                configErrors += $"If {nameof(validate.LoadClaimsFromClaimsFillerProvider)} is true, then {nameof(validate.MaxTime)} must be provided." + System.Environment.NewLine;
+            }
+            if (configErrors is not null)
+            {
+                throw new ConfigurationException(configErrors);
+            }
         }
 
         services.Configure<ClaimsFillerOptions>(options);
@@ -39,10 +49,10 @@ public static class AddClaimsFillerExtension
             }
         }
 
-       AddClaimsFiller(services, o =>
-        {
-            o.LoadClaimsFromClaimsFillerProvider = options.LoadClaimsFromClaimsFillerProvider;
-            o.SettingsKeys = options.SettingsKeys;
-        });
+        AddClaimsFiller(services, o =>
+         {
+             o.LoadClaimsFromClaimsFillerProvider = options.LoadClaimsFromClaimsFillerProvider;
+             o.SettingsKeys = options.SettingsKeys;
+         });
     }
 }

--- a/src/Arc4u.Standard.OAuth2.AspNetCore/Middleware/BasicAuthenticationMiddleware.cs
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore/Middleware/BasicAuthenticationMiddleware.cs
@@ -1,11 +1,8 @@
-using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using System.Linq;
 using System.Net.Http.Headers;
 using System.Text;
-using System.Threading.Tasks;
 using Arc4u.Configuration;
 using Arc4u.Dependency;
 using Arc4u.Diagnostics;
@@ -89,7 +86,7 @@ public class BasicAuthenticationMiddleware
             {
                 tokenInfo = await GetTokenFromCredentialAsync(credential, context.RequestServices).ConfigureAwait(false);
 
-                tokenCache?.Put(cacheKey, tokenInfo);
+                tokenCache?.Put(cacheKey, tokenInfo.ExpiresOnUtc - DateTime.UtcNow, tokenInfo);
             }
 
             if (tokenInfo is not null)

--- a/src/Arc4u.Standard.OAuth2.AspNetCore/Options/ClaimsFillerOptions.cs
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore/Options/ClaimsFillerOptions.cs
@@ -9,7 +9,8 @@ public class ClaimsFillerOptions
     public bool LoadClaimsFromClaimsFillerProvider { get; set; } = true;
 
     /// <summary>
-    /// If <see cref="LoadClaimsFromClaimsFillerProvider"/> is true, the extra claims are cached for <see cref="MaxTime"/>."/>
+    /// If <see cref="LoadClaimsFromClaimsFillerProvider"/> is true, the extra claims are cached for <see cref="MaxTime"/>.
+    /// The default value of 20 minutes provides a balance between performance and data freshness for most use cases.
     /// </summary>
     public TimeSpan MaxTime { get; set; } = TimeSpan.FromMinutes(20);
 

--- a/src/Arc4u.Standard.OAuth2.AspNetCore/Options/ClaimsFillerOptions.cs
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore/Options/ClaimsFillerOptions.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace Arc4u.OAuth2.Options;
 
 /// <summary>
@@ -9,6 +7,11 @@ public class ClaimsFillerOptions
 {
     // By default, a specific claims filler is needed to manage the right.
     public bool LoadClaimsFromClaimsFillerProvider { get; set; } = true;
+
+    /// <summary>
+    /// If <see cref="LoadClaimsFromClaimsFillerProvider"/> is true, the extra claims are cached for <see cref="MaxTime"/>."/>
+    /// </summary>
+    public TimeSpan MaxTime { get; set; } = TimeSpan.FromMinutes(20);
 
     /// <summary>
     /// The settings key to load the claims from. => registered as a named <see cref="SimpleKeyValueSettings>"/>

--- a/src/Arc4u.Standard.OAuth2.AspNetCore/TokenProvider/CredentialTokenCacheTokenProvider.cs
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore/TokenProvider/CredentialTokenCacheTokenProvider.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Threading.Tasks;
-using Arc4u.Configuration;
 using Arc4u.Dependency;
 using Arc4u.Dependency.Attribute;
 using Arc4u.Diagnostics;
@@ -84,7 +81,7 @@ public class CredentialTokenCacheTokenProvider : ICredentialTokenProvider
                 try
                 {
                     _logger.Technical().System($"Save the token in the cache for {cacheKey}, will expire at {tokenInfo.ExpiresOnUtc} Utc.").Log();
-                    TokenCache.Put(cacheKey, tokenInfo);
+                    TokenCache.Put(cacheKey, tokenInfo.ExpiresOnUtc - DateTime.UtcNow, tokenInfo);
                 }
                 catch (Exception ex)
                 {

--- a/src/Arc4u.Standard.OAuth2/Extensions/TokenCacheExtension.cs
+++ b/src/Arc4u.Standard.OAuth2/Extensions/TokenCacheExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using Arc4u.Configuration;
 using Arc4u.OAuth2.Options;
 using Microsoft.Extensions.Configuration;
@@ -54,15 +53,9 @@ public static class TokenCacheExtension
             throw new ConfigurationException("TokenCacheOptions.CacheName is not defined in the configuration file.");
         }
 
-        if (TimeSpan.Zero == tokenCacheOptions.MaxTime)
-        {
-            throw new ConfigurationException("TokenCacheOptions.MaxTime is not defined in the configuration file.");
-        }
-
         services.Configure<TokenCacheOptions>(options =>
         {
             options.CacheName = tokenCacheOptions.CacheName;
-            options.MaxTime = tokenCacheOptions.MaxTime;
         });
     }
 }

--- a/src/Arc4u.Standard.OAuth2/Options/TokenCacheOptions.cs
+++ b/src/Arc4u.Standard.OAuth2/Options/TokenCacheOptions.cs
@@ -1,9 +1,5 @@
-using System;
-
 namespace Arc4u.OAuth2.Options;
 public class TokenCacheOptions
 {
-    public TimeSpan MaxTime { get; set; } = TimeSpan.FromMinutes(20);
-
     public string CacheName { get; set; }
 }

--- a/src/Arc4u.Standard.OAuth2/Security/ClaimsUtility.cs
+++ b/src/Arc4u.Standard.OAuth2/Security/ClaimsUtility.cs
@@ -1,0 +1,117 @@
+#if NET6_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
+using System.Globalization;
+using System.Security.Claims;
+using Arc4u.IdentityModel.Claims;
+
+namespace Arc4u.Standard.OAuth2.Security;
+
+/// <summary>
+/// Claims utilities and extension methods, used in AppPrincipalFactory and AppPrincipalTransform.
+/// </summary>
+/// <remarks>
+/// Claim type comparison is always case-sensitive. See https://www.rfc-editor.org/rfc/rfc7519 section 10.1.
+/// </remarks>
+public static class ClaimsUtility
+{
+    private const string ExpirationClaimType = "exp";
+    private static readonly HashSet<string> ClaimsToExclude = ["aud", "iss", "iat", "nbf", "acr", "aio", "appidacr", "ipaddr", "scp", "sub", "tid", "uti", "unique_name", "apptype", "appid", "ver", "http://schemas.microsoft.com/ws/2008/06/identity/claims/authenticationinstant", "http://schemas.microsoft.com/identity/claims/scope"];
+
+    /// <summary>
+    /// Sanitize the list of external claims by removing the claims we don't need.
+    /// The <paramref name="claims"/> may come from an external system. If there is an "exp" claim in the list, it will be included.
+    /// </summary>
+    /// <param name="claims"></param>
+    /// <returns></returns>
+    public static IEnumerable<ClaimDto> Sanitize(this IEnumerable<ClaimDto> claims)
+    {
+        foreach (var claim in claims)
+        {
+            if (ClaimsToExclude.Contains(claim.ClaimType))
+            {
+                continue;
+            }
+            yield return claim;
+        }
+    }
+
+    /// <summary>
+    /// Sanitize the list of internal claims by removing the claims we don't need. 
+    /// The <paramref name="claims"/> come from the token claims . If there is an "exp" claim in the list, it will be *excluded* as well
+    /// since it may be replaced by the equivalent external claim.
+    /// </summary>
+    /// <param name="claims"></param>
+    /// <returns></returns>
+    public static IEnumerable<Claim> Sanitize(this IEnumerable<Claim> claims)
+    {
+        foreach (var claim in claims)
+        {
+            if (ClaimsToExclude.Contains(claim.Type) || claim.Type == ExpirationClaimType)
+            {
+                continue;
+            }
+            yield return claim;
+        }
+    }
+
+    /// <summary>
+    /// Merge the <paramref name="claimsToMerge"/> into the <paramref name="claimsIdentity"/>, but only the claims that are not already present.
+    /// The "exp" claim is always excluded from the merge.
+    /// </summary>
+    /// <param name="claimsIdentity"></param>
+    /// <param name="claimsToMerge"></param>
+    public static void MergeClaims(this ClaimsIdentity claimsIdentity, IEnumerable<ClaimDto> claimsToMerge)
+    {
+        claimsIdentity.AddClaims(claimsToMerge.Where(c => c.ClaimType != ExpirationClaimType && !claimsIdentity.HasClaim(c1 => c1.Type == c.ClaimType)).Select(c => new Claim(c.ClaimType, c.Value)));
+    }
+
+    /// <summary>
+    /// Merge the <paramref name="claimsToMerge"/> into the <paramref name="claimsIdentity"/>, but only the claims that are not already present.
+    /// The "exp" claim is always excluded from the merge.
+    /// </summary>
+    /// <param name="claimsIdentity"></param>
+    /// <param name="claimsToMerge"></param>
+    public static void MergeClaims(this ClaimsIdentity claimsIdentity, IEnumerable<Claim> claimsToMerge)
+    {
+        claimsIdentity.AddClaims(claimsToMerge.Where(c => c.Type != ExpirationClaimType && !claimsIdentity.HasClaim(c1 => c1.Type == c.Type)).Select(c => new Claim(c.Type, c.Value)));
+    }
+
+#if NET6_0_OR_GREATER
+    public static bool TryGetExpiration(this IEnumerable<Claim> claims, [NotNullWhen(true)] out Claim? expClaim)
+#else
+    public static bool TryGetExpiration(this IEnumerable<Claim> claims, out Claim expClaim)
+#endif
+    {
+        expClaim = claims.FirstOrDefault(c => c.Type == ExpirationClaimType);
+        return expClaim is not null;
+    }
+
+    public static bool TryGetExpiration(this IEnumerable<Claim> claims, out long ticks)
+    {
+        var claim = claims.FirstOrDefault(c => c.Type == ExpirationClaimType);
+
+        if (claim is null)
+        {
+            ticks = 0;
+            return false;
+        }
+
+        return claim.Value.TryParseTicks(out ticks);
+    }
+
+    public static bool TryGetExpiration(this IEnumerable<ClaimDto> claims, out long ticks)
+    {
+        var claim = claims.FirstOrDefault(c => c.ClaimType == ExpirationClaimType);
+
+        if (claim is null)
+        {
+            ticks = 0;
+            return false;
+        }
+
+        return claim.Value.TryParseTicks(out ticks);
+    }
+
+    public static bool TryParseTicks(this string s, out long ticks) => long.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out ticks);
+}

--- a/src/Arc4u.Standard.OAuth2/Token/ApplicationCache.cs
+++ b/src/Arc4u.Standard.OAuth2/Token/ApplicationCache.cs
@@ -4,8 +4,6 @@ using Arc4u.Diagnostics;
 using Arc4u.OAuth2.Options;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using System;
-using System.Collections.Generic;
 
 namespace Arc4u.OAuth2.Token
 {
@@ -40,7 +38,7 @@ namespace Arc4u.OAuth2.Token
             _logger.Technical().From<ApplicationCache>().System($"Deleted information from the token cache for the id: {id}.").Log();
         }
 
-        public void Put<T>(string key, T data)
+        public void Put<T>(string key, TimeSpan timeout, T data)
         {
             if (null == data)
             {
@@ -49,7 +47,7 @@ namespace Arc4u.OAuth2.Token
             }
 
             _logger.Technical().From<ApplicationCache>().System($"Adding token data information to the cache: {key}.").Log();
-            _cache.Put(GetKey(key), _tokenCacheOptions.MaxTime, data);
+            _cache.Put(GetKey(key), timeout, data);
             _logger.Technical().From<ApplicationCache>().System($"Added token data information to the cache: {key}.").Log();
         }
 

--- a/src/Arc4u.Standard.OAuth2/Token/ApplicationLocalDataCache.cs
+++ b/src/Arc4u.Standard.OAuth2/Token/ApplicationLocalDataCache.cs
@@ -2,7 +2,6 @@ using Arc4u.Caching;
 using Arc4u.Dependency.Attribute;
 using Arc4u.Diagnostics;
 using Microsoft.Extensions.Logging;
-using System;
 
 namespace Arc4u.OAuth2.Token
 {
@@ -37,7 +36,7 @@ namespace Arc4u.OAuth2.Token
             Clear(key);
         }
 
-        public void Put<T>(string key, T data)
+        public void Put<T>(string key, TimeSpan timeout, T data)
         {
             try
             {

--- a/src/Arc4u.Standard.OAuth2/Token/ITokenCache.cs
+++ b/src/Arc4u.Standard.OAuth2/Token/ITokenCache.cs
@@ -11,7 +11,7 @@ namespace Arc4u.OAuth2.Token
 
         /// <summary>
         /// Set or overwrite the item with key <paramref name="key"/> with <paramref name="data"/>.
-        /// The item expires after <paramref name="timeout"/>
+        /// The item expires after <paramref name="timeout"/>.
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="key"></param>

--- a/src/Arc4u.Standard.OAuth2/Token/ITokenCache.cs
+++ b/src/Arc4u.Standard.OAuth2/Token/ITokenCache.cs
@@ -1,4 +1,4 @@
-﻿namespace Arc4u.OAuth2.Token
+namespace Arc4u.OAuth2.Token
 {
     public interface ITokenCache
     {
@@ -9,7 +9,15 @@
         void DeleteItem(string key);
 
 
-        void Put<T>(string key, T data);
+        /// <summary>
+        /// Set or overwrite the item with key <paramref name="key"/> with <paramref name="data"/>.
+        /// The item expires after <paramref name="timeout"/>
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="key"></param>
+        /// <param name="timeout"></param>
+        /// <param name="data"></param>
+        void Put<T>(string key, TimeSpan timeout, T data);
 
         T Get<T>(string key);
 

--- a/src/Arc4u.Standard.UnitTest/Security/JwtHttpHandlerTests.cs
+++ b/src/Arc4u.Standard.UnitTest/Security/JwtHttpHandlerTests.cs
@@ -1,13 +1,7 @@
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IdentityModel.Tokens.Jwt;
-using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Security.Claims;
-using System.Threading;
-using System.Threading.Tasks;
 using Arc4u.Caching;
 using Arc4u.Configuration;
 using Arc4u.Dependency.ComponentModel;
@@ -115,13 +109,13 @@ public class JwtHttpHandlerTests
 
         // Create a scope to be in the context majority of the time a business code is.
         using var scopedContainer = container.CreateScope();
-       
+
         scopedServiceAccessor.ServiceProvider = scopedContainer.ServiceProvider;
 
         var tokenRefresh = scopedContainer.Resolve<TokenRefreshInfo>();
         tokenRefresh.RefreshToken = new TokenInfo("refresh_token", Guid.NewGuid().ToString(), DateTime.UtcNow.AddHours(1));
         tokenRefresh.AccessToken = new TokenInfo("access_token", accessToken);
-       
+
         // Define a Principal with no OAuth2Bearer token here => we test the injection.
         var appContext = scopedContainer.Resolve<IApplicationContext>();
         appContext.SetPrincipal(new AppPrincipal(new Arc4u.Security.Principal.Authorization(), new ClaimsIdentity(Constants.CookiesAuthenticationType), "S-1-0-0"));
@@ -201,7 +195,7 @@ public class JwtHttpHandlerTests
 
         // Define a Principal with no OAuth2Bearer token here => we test the injection.
         var appContext = scopedContainer.Resolve<IApplicationContext>();
-        appContext.SetPrincipal(new AppPrincipal(new Arc4u.Security.Principal.Authorization(), new ClaimsIdentity(Constants.BearerAuthenticationType) { BootstrapContext = accessToken}, "S-1-0-0"));
+        appContext.SetPrincipal(new AppPrincipal(new Arc4u.Security.Principal.Authorization(), new ClaimsIdentity(Constants.BearerAuthenticationType) { BootstrapContext = accessToken }, "S-1-0-0"));
 
         var setingsOptions = scopedContainer.Resolve<IOptionsMonitor<SimpleKeyValueSettings>>();
 
@@ -247,7 +241,7 @@ public class JwtHttpHandlerTests
             ["Authentication:ClientSecrets:Client1:Credential"] = $"{options.User}:password",
             ["Authentication:DefaultAuthority:Url"] = "https://login.microsoft.com"
         };
-        foreach(var scope in options.Scopes)
+        foreach (var scope in options.Scopes)
         {
             configDic.Add($"Authentication:ClientSecrets:Client1:Scopes:{options.Scopes.IndexOf(scope)}", scope);
         }
@@ -277,7 +271,7 @@ public class JwtHttpHandlerTests
         // Mock the cache used by the Credential token provider.
         var mockTokenCache = _fixture.Freeze<Mock<ITokenCache>>();
         mockTokenCache.Setup(m => m.Get<TokenInfo>(It.IsAny<string>())).Returns((TokenInfo)null);
-        mockTokenCache.Setup(m => m.Put<TokenInfo>(It.IsAny<string>(), It.IsAny<TokenInfo>()));
+        mockTokenCache.Setup(m => m.Put<TokenInfo>(It.IsAny<string>(), TimeSpan.MaxValue, It.IsAny<TokenInfo>()));
 
 
         var mockHttpContextAccessor = _fixture.Freeze<Mock<IHttpContextAccessor>>();

--- a/src/Arc4u.Standard.UnitTest/Security/TokenCacheOptionsTests.cs
+++ b/src/Arc4u.Standard.UnitTest/Security/TokenCacheOptionsTests.cs
@@ -1,15 +1,13 @@
-using AutoFixture.AutoMoq;
-using AutoFixture;
-using Xunit;
-using Microsoft.Extensions.DependencyInjection;
+using Arc4u.Configuration;
 using Arc4u.OAuth2.Extensions;
 using Arc4u.OAuth2.Options;
-using Microsoft.Extensions.Options;
+using AutoFixture;
+using AutoFixture.AutoMoq;
 using FluentAssertions;
-using System;
 using Microsoft.Extensions.Configuration;
-using System.Collections.Generic;
-using Arc4u.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
 
 namespace Arc4u.UnitTest.Security;
 
@@ -41,7 +39,6 @@ public class TokenCacheOptionsTests
         var sut = options.Value;
 
         sut.CacheName.Should().Be("test");
-        sut.MaxTime.Should().Be(TimeSpan.FromMinutes(20));
     }
 
     [Fact]
@@ -56,7 +53,6 @@ public class TokenCacheOptionsTests
                   new Dictionary<string, string?>
                   {
                       ["Authentication:TokenCache:CacheName"] = options.CacheName,
-                      ["Authentication:TokenCache:MaxTime"] = options.MaxTime.ToString(),
                   }).Build();
 
         IConfiguration configuration = new ConfigurationRoot(new List<IConfigurationProvider>(config.Providers));
@@ -70,7 +66,6 @@ public class TokenCacheOptionsTests
         var sut = sutOptions.Value;
 
         sut.CacheName.Should().Be(options.CacheName);
-        sut.MaxTime.Should().Be(options.MaxTime);
     }
 
     [Fact]
@@ -99,7 +94,6 @@ public class TokenCacheOptionsTests
         var sut = sutOptions.Value;
 
         sut.CacheName.Should().Be(options.CacheName);
-        sut.MaxTime.Should().Be(defaultOptions.MaxTime);
     }
 
     [Fact]
@@ -113,8 +107,7 @@ public class TokenCacheOptionsTests
               .AddInMemoryCollection(
                   new Dictionary<string, string?>
                   {
-                      ["Authentication:TokenCache:CacheName"] = options.CacheName,
-                      ["Authentication:TokenCache:MaxTime"] = TimeSpan.Zero.ToString(),
+                      ["Authentication:TokenCache:CacheName"] = options.CacheName
                   }).Build();
 
         IConfiguration configuration = new ConfigurationRoot(new List<IConfigurationProvider>(config.Providers));
@@ -134,8 +127,7 @@ public class TokenCacheOptionsTests
               .AddInMemoryCollection(
                   new Dictionary<string, string?>
                   {
-                      ["Authentication:TokenCache:CacheName"] = "",
-                      ["Authentication:TokenCache:MaxTime"] = TimeSpan.FromMinutes(20).ToString(),
+                      ["Authentication:TokenCache:CacheName"] = ""
                   }).Build();
 
         IConfiguration configuration = new ConfigurationRoot(new List<IConfigurationProvider>(config.Providers));

--- a/src/Arc4u.Standard.UnitTest/Security/gRpcInterceptorTests.cs
+++ b/src/Arc4u.Standard.UnitTest/Security/gRpcInterceptorTests.cs
@@ -1,9 +1,6 @@
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
-using System.Threading;
 using Arc4u.Caching;
 using Arc4u.Configuration;
 using Arc4u.Dependency;
@@ -11,7 +8,9 @@ using Arc4u.Dependency.ComponentModel;
 using Arc4u.Diagnostics;
 using Arc4u.gRPC.Interceptors;
 using Arc4u.OAuth2;
+using Arc4u.OAuth2.AspNetCore;
 using Arc4u.OAuth2.Extensions;
+using Arc4u.OAuth2.Options;
 using Arc4u.OAuth2.Security.Principal;
 using Arc4u.OAuth2.Token;
 using Arc4u.OAuth2.TokenProvider;
@@ -20,7 +19,9 @@ using Arc4u.Security.Principal;
 using AutoFixture;
 using AutoFixture.AutoMoq;
 using FluentAssertions;
+using Grpc.Core;
 using Grpc.Core.Interceptors;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -29,10 +30,6 @@ using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
 using static Grpc.Core.Interceptors.Interceptor;
-using Grpc.Core;
-using Arc4u.OAuth2.Options;
-using Microsoft.AspNetCore.Http;
-using Arc4u.OAuth2.AspNetCore;
 
 namespace Arc4u.UnitTest.Security;
 
@@ -233,7 +230,7 @@ public class GRpcInterceptorTests
             ["Authentication:ClientSecrets:Client1:Credential"] = $"{options.User}:password",
             ["Authentication:DefaultAuthority:Url"] = "https://login.microsoft.com"
         };
-        foreach(var scope in options.Scopes)
+        foreach (var scope in options.Scopes)
         {
             configDic.Add($"Authentication:ClientSecrets:Client1:Scopes:{options.Scopes.IndexOf(scope)}", scope);
         }
@@ -266,7 +263,7 @@ public class GRpcInterceptorTests
         // Mock the cache used by the Credential token provider.
         var mockTokenCache = _fixture.Freeze<Mock<ITokenCache>>();
         mockTokenCache.Setup(m => m.Get<TokenInfo>(It.IsAny<string>())).Returns((TokenInfo)null);
-        mockTokenCache.Setup(m => m.Put<TokenInfo>(It.IsAny<string>(), It.IsAny<TokenInfo>()));
+        mockTokenCache.Setup(m => m.Put<TokenInfo>(It.IsAny<string>(), TimeSpan.MaxValue, It.IsAny<TokenInfo>()));
 
         // Register the different TokenProvider and CredentialTokenProviders.
         var container = new ComponentModelContainer(services);
@@ -539,7 +536,7 @@ public class GRpcInterceptorTests
         services.AddScoped<IApplicationContext, ApplicationInstanceContext>();
         services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
 
-                // Register the different TokenProvider and CredentialTokenProviders.
+        // Register the different TokenProvider and CredentialTokenProviders.
         var container = new ComponentModelContainer(services);
         container.Register<ITokenProvider, BootstrapContextTokenProvider>("Bootstrap");
         container.CreateContainer();


### PR DESCRIPTION
This pull request eliminates the reliance on a fixed timeout for the token cache.
In other words, the `MaxTime` settings in the following section:

~~~json
    "TokenCache": {
      "CacheName": "Volatile",
      "MaxTime": "00:00:20"
    },
~~~

... isn't used anymore and can be eliminated.

The reasoning behind the modification is that the implicit validity of the cached information is never longer than the expiration date of the stored token. And in all use cases except one, the expiration date can be obtained from the token information being stored (i.e. the `exp` claim). This makes the explicit setting in the configuration unnecessary.

The only exception is the "extra claims" than can optionally be loaded. These extra claims are cached. It is expected that the `IClaimsFiller` implementation returns an `exp` claim. If it doesn't, the code now looks for an `exp` claim in the existing `ClaimsPrincipal`. And if for some reason _that_ fails, we need a timeout. This timeout is now part of the `ClaimsFillerOptions`. It is called `MaxTime` as before, and defaults to 20 minutes if it isn't specified (since in existing code, it would not be). 

The code `AppPrincipalTransform.cs` has been optimized to avoid needless list copying, and to systematically compare claim types case-insensitively.

What is still missing in this PR is a way to explicitly delete cached entries when the user logs off. It also doesn't change the way cache keys are computed.

According to https://www.rfc-editor.org/rfc/rfc7519 section 10.1, claim names (a.k.a. "types") are case-sensitive: this has been enacted throughout the code.
Claims manipulations have been factored out in a separate utility class.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced token caching mechanism to dynamically calculate expiration times.
	- Introduced utility methods for improved claims handling in OAuth2 security contexts.

- **Bug Fixes**
	- Improved error handling in claims filling process.

- **Refactor**
	- Streamlined claim handling and caching logic for better performance.
	- Simplified configuration validation for claims filling.
	- Updated method signatures to support new caching strategies.

- **Documentation**
	- Added XML documentation to clarify method functionalities and parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->