### PR TITLE
update nservicebus in arc4u nservicebus packages

### DIFF
--- a/src/Arc4u.Standard.NServiceBus.Core/Arc4u.Standard.NServiceBus.Core.csproj
+++ b/src/Arc4u.Standard.NServiceBus.Core/Arc4u.Standard.NServiceBus.Core.csproj
@@ -3,8 +3,11 @@
     <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <PackageId>Arc4u.Standard.NServiceBus.Core</PackageId>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="7.8.0" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+    <PackageReference Include="NServiceBus" Version="8.2.3" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+    <PackageReference Include="NServiceBus" Version="9.1.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Arc4u.Standard.Dependency\Arc4u.Standard.Dependency.csproj" />

--- a/src/Arc4u.Standard.NServiceBus.RabbitMQ/Arc4u.Standard.NServiceBus.RabbitMQ.csproj
+++ b/src/Arc4u.Standard.NServiceBus.RabbitMQ/Arc4u.Standard.NServiceBus.RabbitMQ.csproj
@@ -4,8 +4,13 @@
     <PackageId>Arc4u.Standard.NServiceBus.RabbitMQ</PackageId>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NServiceBus.RabbitMQ" Version="6.1.6" />
     <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+    <PackageReference Include="NServiceBus.RabbitMQ" Version="8.0.5" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+    <PackageReference Include="NServiceBus.RabbitMQ" Version="9.1.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Arc4u.Standard.Caching\Arc4u.Standard.Caching.csproj" />

--- a/src/Arc4u.Standard.NServiceBus.RabbitMQ/Routing/PublisherRootingTopology.cs
+++ b/src/Arc4u.Standard.NServiceBus.RabbitMQ/Routing/PublisherRootingTopology.cs
@@ -1,9 +1,10 @@
-﻿using Arc4u.Diagnostics;
+using Arc4u.Diagnostics;
 using NServiceBus.Transport;
 using NServiceBus.Transport.RabbitMQ;
 using RabbitMQ.Client;
 using System;
 using System.Collections.Generic;
+using NServiceBus.Unicast.Messages;
 
 namespace Arc4u.NServiceBus.RabbitMQ.Routing
 {
@@ -16,11 +17,11 @@ namespace Arc4u.NServiceBus.RabbitMQ.Routing
 
         private Func<Type, String> ExchangeName;
 
-        public void SetupSubscription(IModel channel, Type type, string subscriberName)
+        public void SetupSubscription(IModel channel, MessageMetadata type, string subscriberName)
         {
         }
 
-        public void TeardownSubscription(IModel channel, Type type, string subscriberName)
+        public void TeardownSubscription(IModel channel, MessageMetadata type, string subscriberName)
         {
         }
 

--- a/src/Arc4u.Standard.NServiceBus/Arc4u.Standard.NServiceBus.csproj
+++ b/src/Arc4u.Standard.NServiceBus/Arc4u.Standard.NServiceBus.csproj
@@ -3,15 +3,14 @@
     <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <PackageId>Arc4u.Standard.NServiceBus</PackageId>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="7.8.0" />
-  </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.4" />
+    <PackageReference Include="NServiceBus" Version="8.2.3" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
-  </ItemGroup>  
+    <PackageReference Include="NServiceBus" Version="9.1.1" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Arc4u.Standard.Caching\Arc4u.Standard.Caching.csproj" />
     <ProjectReference Include="..\Arc4u.Standard.Core\Arc4u.Standard.Core.csproj" />


### PR DESCRIPTION
update nservicebus in arc4u nservicebus packages
update nservicebus.rabbitmq to .net 8 version + adjuste publisherrootingtopology

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced package references for improved compatibility with .NET versions 6.0 and 8.0.
	- Updated subscription management methods to accept more relevant input types.

- **Bug Fixes**
	- Resolved issues related to outdated package versions, ensuring better performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->