### PR TITLE
feature: Add TracingHandler for correlationId propagation.

### DIFF
--- a/src/Arc4u.Standard.Diagnostics/Arc4u.Standard.Diagnostics.csproj
+++ b/src/Arc4u.Standard.Diagnostics/Arc4u.Standard.Diagnostics.csproj
@@ -4,14 +4,17 @@
     <PackageId>Arc4u.Standard.Diagnostics</PackageId>
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>  
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
     <PackageReference Include="System.Text.Json" Version="9.0.0" />
   </ItemGroup>

--- a/src/Arc4u.Standard.Diagnostics/Telemetry/CorrelationIdActityExtensions.cs
+++ b/src/Arc4u.Standard.Diagnostics/Telemetry/CorrelationIdActityExtensions.cs
@@ -1,0 +1,61 @@
+using System.Diagnostics;
+
+namespace Arc4u.Diagnostics.Telemetry;
+
+public static class CorrelationIdActityExtensions
+{
+    /// <summary>
+    /// Adds a new correlationId to the activity.
+    /// </summary>
+    /// <param name="activity">The activity.</param>
+    /// <returns></returns>
+    public static Activity WithCorrelationId(this Activity activity)
+        => activity.WithCorrelationId(Guid.NewGuid().ToString());
+
+    /// <summary>
+    /// Adds a new correlationId to the activity.
+    /// </summary>
+    /// <param name="activity">The activity.</param>
+    /// <param name="correlationId">The correlation identifier.</param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentNullException"></exception>
+    public static Activity WithCorrelationId(this Activity activity, string correlationId)
+    {
+        if (activity == null)
+        {
+            throw new ArgumentNullException(nameof(activity));
+        }
+
+        if (correlationId == null)
+        {
+            throw new ArgumentNullException(correlationId);
+        }
+
+        return activity.SetTag(CorrelationIdHttpHeaders.CorrelationId, correlationId);
+    }
+
+    /// <summary>
+    /// Gets the correlation identifier associated with <see cref="Activity"/>
+    /// </summary>
+    /// <param name="activity">The activity.</param>
+    /// <returns></returns>
+    public static string? GetCorrelationId(this Activity activity)
+    {
+        var currentActivity = activity;
+
+        while (currentActivity is not null)
+        {
+            var correlationId = (string?)currentActivity.GetTagItem(CorrelationIdHttpHeaders.CorrelationId);
+
+            if (correlationId != null)
+            {
+                return correlationId;
+            }
+
+            currentActivity = currentActivity.Parent;
+        }
+
+        return null;
+    }
+
+}

--- a/src/Arc4u.Standard.Diagnostics/Telemetry/CorrelationIdHttpHeaders.cs
+++ b/src/Arc4u.Standard.Diagnostics/Telemetry/CorrelationIdHttpHeaders.cs
@@ -1,0 +1,10 @@
+﻿namespace Arc4u.Diagnostics.Telemetry;
+
+public class CorrelationIdHttpHeaders
+{
+    /// <summary>
+    /// Correlation Id
+    /// This field is used to track requests across services boundaries
+    /// </summary>
+    public const string CorrelationId = "correlation-id";
+}

--- a/src/Arc4u.Standard.Diagnostics/Telemetry/TracingHandler.cs
+++ b/src/Arc4u.Standard.Diagnostics/Telemetry/TracingHandler.cs
@@ -1,0 +1,68 @@
+using System.Diagnostics;
+using Arc4u.Diagnostics;
+using Arc4u.Diagnostics.Telemetry;
+using Microsoft.Extensions.Logging;
+using OpenTelemetry;
+using OpenTelemetry.Context.Propagation;
+
+namespace Arc4u.Standard.Diagnostics.Telemetry;
+public sealed class TracingHandler(IActivitySourceFactory defaultActivitySourceFactory, ILogger<TracingHandler> logger) : DelegatingHandler
+{
+    private readonly ActivitySource _activitySource = defaultActivitySourceFactory.GetArc4u();
+    private readonly ILogger<TracingHandler> _logger = logger;
+    private static readonly TextMapPropagator Propagator = new TraceContextPropagator();
+
+    /// <inheritdoc />
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var activity = Activity.Current;
+        bool shouldStopActivity = false;
+
+        try
+        {
+            if (activity is null)
+            {
+                _logger.Technical().Warning("No activity found! Creating default one with {name} as name. Tracing a correlationId will not be possible.", request.RequestUri!.ToString());
+                activity = _activitySource.StartActivity(request.RequestUri!.ToString());
+                shouldStopActivity = true;
+            }
+
+            var correlationId = activity?.GetCorrelationId();
+            if (correlationId is null)
+            {
+                activity = activity?.WithCorrelationId();
+                correlationId = activity?.GetCorrelationId();
+            }
+
+            if (activity is not null)
+            {
+                Propagator.Inject(new PropagationContext(activity.Context, Baggage.Current),
+                    request.Headers, (headers, name, value) => headers.Add(name, value));
+            }
+
+            request.Headers.Add(CorrelationIdHttpHeaders.CorrelationId, correlationId ?? Guid.NewGuid().ToString("D"));
+
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+
+            if(activity is not null)
+            {
+                await response.Content.LoadIntoBufferAsync().ConfigureAwait(false);
+                var ctx =  Propagator.Extract(default, response, (response, name) =>
+                    response.Headers.Contains(name)? response.Headers.GetValues(name) : []);
+                Baggage.SetBaggage(ctx.Baggage.GetBaggage()!);
+            }
+
+            //Propagate the correlationId in the response.
+            response.Headers.Add(CorrelationIdHttpHeaders.CorrelationId, correlationId);
+
+            return response;
+        }
+        finally
+        {
+            if (shouldStopActivity)
+            {
+                activity?.Stop();
+            }
+        }
+    }
+}

--- a/src/Arc4u.Standard.UnitTest/Arc4u.Standard.UnitTest.csproj
+++ b/src/Arc4u.Standard.UnitTest/Arc4u.Standard.UnitTest.csproj
@@ -35,6 +35,7 @@
     <PackageReference Include="AutoFixture.SeedExtensions" Version="4.18.1" />
     <PackageReference Include="AutoFixture.Xunit2" Version="4.18.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
@@ -61,6 +62,7 @@
     <ProjectReference Include="..\Arc4u.Standard.Dependency.ComponentModel\Arc4u.Standard.Dependency.ComponentModel.csproj" />
     <ProjectReference Include="..\Arc4u.Standard.Dependency\Arc4u.Standard.Dependency.csproj" />
     <ProjectReference Include="..\Arc4u.Standard.Diagnostics.Serilog\Arc4u.Standard.Diagnostics.Serilog.csproj" />
+    <ProjectReference Include="..\Arc4u.Standard.Diagnostics\Arc4u.Standard.Diagnostics.csproj" />
     <ProjectReference Include="..\Arc4u.Standard.EfCore\Arc4u.Standard.EfCore.csproj" />
     <ProjectReference Include="..\Arc4u.Standard.gRPC\Arc4u.Standard.gRPC.csproj" />
     <ProjectReference Include="..\Arc4u.Standard.MongoDB\Arc4u.Standard.MongoDB.csproj" />

--- a/src/Arc4u.Standard.UnitTest/Diagnostics/TracingHandlerTests.cs
+++ b/src/Arc4u.Standard.UnitTest/Diagnostics/TracingHandlerTests.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using Arc4u.Diagnostics;
 using Arc4u.Diagnostics.Telemetry;
+using Arc4u.Standard.Diagnostics.Telemetry;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;

--- a/src/Arc4u.Standard.UnitTest/Diagnostics/TracingHandlerTests.cs
+++ b/src/Arc4u.Standard.UnitTest/Diagnostics/TracingHandlerTests.cs
@@ -1,0 +1,94 @@
+using System.Diagnostics;
+using Arc4u.Diagnostics;
+using Arc4u.Diagnostics.Telemetry;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using RichardSzalay.MockHttp;
+using Xunit;
+
+namespace Arc4u.Standard.UnitTest.Diagnostics;
+
+[Trait("Category", "Diagnostics")]
+public class TracingHandlerTests
+{
+    [Fact]
+    public async Task When_Sending_A_HttpCall_It_Should_Add_CorrelationId()
+    {
+        var activityListener = new ActivityListener
+        {
+            ShouldListenTo = s => true,
+            SampleUsingParentId = (ref ActivityCreationOptions<string> activityOptions) => ActivitySamplingResult.AllData,
+            Sample = (ref ActivityCreationOptions<ActivityContext> activityOptions) => ActivitySamplingResult.AllData
+        };
+
+
+        // Arrange
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp.When(HttpMethod.Get, "http://localhost/api/test")
+            .Respond("application/json", "{'name':'test'}");
+
+        var nullLogger = new NullLogger<TracingHandler>();
+        var defaultActivitySourceFactoryMock = new Mock<IActivitySourceFactory>();
+        defaultActivitySourceFactoryMock.Setup(x => x.Get(It.IsAny<string>(), It.IsAny<string>())).Returns(new ActivitySource("Arc4u", "1.0.0"));
+
+
+        var activitySource = defaultActivitySourceFactoryMock.Object.Get("Arc4u");
+        ActivitySource.AddActivityListener(activityListener);
+        Activity.Current = activitySource.StartActivity(nameof(When_Sending_A_HttpCall_It_Should_Add_CorrelationId));
+
+        var tracingHandler = new TracingHandler(defaultActivitySourceFactoryMock.Object, nullLogger)
+        {
+            InnerHandler = mockHttp
+        };
+        var client = new HttpClient(tracingHandler);
+
+        //Act
+        var response = await client.GetAsync("http://localhost/api/test");
+
+        //Assert
+        response.Should().NotBeNull();
+        response.Headers.Should().ContainKey(CorrelationIdHttpHeaders.CorrelationId);
+    }
+
+    [Fact]
+    public async Task When_Sending_A_HttpCall_An_Existing_CorrelationId_Should_Be_Propagated()
+    {
+        var correlationId = Guid.NewGuid().ToString("D");
+        var activityListener = new ActivityListener
+        {
+            ShouldListenTo = s => true,
+            SampleUsingParentId = (ref ActivityCreationOptions<string> activityOptions) => ActivitySamplingResult.AllData,
+            Sample = (ref ActivityCreationOptions<ActivityContext> activityOptions) => ActivitySamplingResult.AllData
+        };
+        // Arrange
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp.When(HttpMethod.Get, "http://localhost/api/test")
+            .Respond("application/json", "{'name':'test'}");
+        var nullLogger = new NullLogger<TracingHandler>();
+        var defaultActivitySourceFactoryMock = new Mock<IActivitySourceFactory>();
+        defaultActivitySourceFactoryMock.Setup(x => x.Get(It.IsAny<string>(), It.IsAny<string>())).Returns(new ActivitySource("Arc4u", "1.0.0"));
+        var activitySource = defaultActivitySourceFactoryMock.Object.Get("Arc4u");
+
+        ActivitySource.AddActivityListener(activityListener);
+        Activity.Current = activitySource.StartActivity(nameof(When_Sending_A_HttpCall_An_Existing_CorrelationId_Should_Be_Propagated))
+            ?.AddTag(CorrelationIdHttpHeaders.CorrelationId, correlationId);
+
+        var tracingHandler = new TracingHandler(defaultActivitySourceFactoryMock.Object, nullLogger)
+        {
+            InnerHandler = mockHttp
+        };
+        var client = new HttpClient(tracingHandler);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "http://localhost/api/test");
+        request.Headers.Add(CorrelationIdHttpHeaders.CorrelationId, correlationId);
+        //Act
+        var response = await client.SendAsync(request);
+
+        //Assert
+        response.Should().NotBeNull();
+        response.Headers.Should().ContainKey(CorrelationIdHttpHeaders.CorrelationId);
+        response.Headers.GetValues(CorrelationIdHttpHeaders.CorrelationId).First().Should().Be(correlationId);
+    }
+}
+


### PR DESCRIPTION
Introduced `CorrelationIdHttpHeaders` and `CorrelationIdActityExtensions` classes in `Arc4u.Diagnostics.Telemetry` namespace for managing correlation IDs. Implemented `TracingHandler` class to handle HTTP requests and responses, ensuring correlation IDs are propagated correctly. Added unit tests in `TracingHandlerTests` to verify the behavior of `TracingHandler`.