### PR TITLE
Added warning for zero size limit

### DIFF
--- a/src/Arc4u.Standard.Caching.Memory/MemoryCache.cs
+++ b/src/Arc4u.Standard.Caching.Memory/MemoryCache.cs
@@ -57,6 +57,9 @@ public class MemoryCache : BaseDistributeCache<MemoryCache>, ICache
 
                 var config = _options.Get(store);
 
+                if (config.SizeLimitInMB <= 0)
+                    _logger.LogWarning("The size limit for the {store} cache is {sizeLimitInMB}.", store, config.SizeLimitInMB);
+
                 var option = new DistriOption(new MemoryDistributedCacheOptions
                 {
                     CompactionPercentage = config.CompactionPercentage,

--- a/src/Arc4u.Standard.Caching/Arc4u.Standard.Caching.csproj
+++ b/src/Arc4u.Standard.Caching/Arc4u.Standard.Caching.csproj
@@ -3,6 +3,7 @@
     <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
     <PackageId>Arc4u.Standard.Caching</PackageId>
     <Nullable>enable</Nullable>
+    <NoWarn>$(NoWarn);IDE0130</NoWarn>
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />

--- a/src/Arc4u.Standard.Caching/BaseDistributeCache.cs
+++ b/src/Arc4u.Standard.Caching/BaseDistributeCache.cs
@@ -11,13 +11,13 @@ public abstract class BaseDistributeCache<T> : ICache
 {
     private bool disposed;
 
-    protected DistributedCacheEntryOptions DefaultOption = new DistributedCacheEntryOptions();
+    protected DistributedCacheEntryOptions DefaultOption = new();
     private IObjectSerialization? _serializerFactory;
     private readonly ILogger<T> _logger;
 
     protected IDistributedCache? DistributeCache { get; set; }
 
-    protected readonly object _lock = new object();
+    protected readonly object _lock = new();
     protected bool IsInitialized { get; set; }
 
     // The reason why the cache is not initialized, this will be used when an exception is thrown.
@@ -28,7 +28,7 @@ public abstract class BaseDistributeCache<T> : ICache
     protected IContainerResolve Container => _container;
     private readonly ActivitySource? _activitySource;
 
-    public BaseDistributeCache(ILogger<T> logger, IContainerResolve container)
+    protected BaseDistributeCache(ILogger<T> logger, IContainerResolve container)
     {
 #if NETSTANDARD2_0
         if (null == container)
@@ -85,7 +85,7 @@ public abstract class BaseDistributeCache<T> : ICache
             blob = DistributeCache?.Get(key);
             if (null == blob)
             {
-                return default(TValue);
+                return default;
             }
 
             using var serializerActivity = _activitySource?.StartActivity("Deserialize.", ActivityKind.Producer);
@@ -97,7 +97,7 @@ public abstract class BaseDistributeCache<T> : ICache
         }
     }
 
-    public async Task<TValue?> GetAsync<TValue>(string key, CancellationToken cancellation = default(CancellationToken))
+    public async Task<TValue?> GetAsync<TValue>(string key, CancellationToken cancellation = default)
     {
         CheckIfInitialized();
 
@@ -110,7 +110,7 @@ public abstract class BaseDistributeCache<T> : ICache
             blob = DistributeCache is null ? null : await DistributeCache.GetAsync(key, cancellation).ConfigureAwait(false);
             if (null == blob)
             {
-                return default(TValue);
+                return default;
             }
 
             using var serializerActivity = _activitySource?.StartActivity("Deserialize.", ActivityKind.Producer);
@@ -144,7 +144,7 @@ public abstract class BaseDistributeCache<T> : ICache
         CheckIfInitialized();
 
 #if NET8_0_OR_GREATER
-        if (EqualityComparer<TValue>.Default.Equals(value, default(TValue)))
+        if (EqualityComparer<TValue>.Default.Equals(value, default))
 #else
         if (value == null)
 #endif
@@ -164,7 +164,7 @@ public abstract class BaseDistributeCache<T> : ICache
         DistributeCache?.Set(key, blob, DefaultOption);
     }
 
-    public async Task PutAsync<TValue>(string key, TValue value, CancellationToken cancellation = default(CancellationToken))
+    public async Task PutAsync<TValue>(string key, TValue value, CancellationToken cancellation = default)
     {
         CheckIfInitialized();
 
@@ -276,7 +276,7 @@ public abstract class BaseDistributeCache<T> : ICache
         }
 
     }
-    public async Task<bool> RemoveAsync(string key, CancellationToken cancellation = default(CancellationToken))
+    public async Task<bool> RemoveAsync(string key, CancellationToken cancellation = default)
     {
         using var activity = _activitySource?.StartActivity("Remove from cache.", ActivityKind.Producer);
 
@@ -309,13 +309,13 @@ public abstract class BaseDistributeCache<T> : ICache
         }
         catch (Exception)
         {
-            value = default(TValue);
+            value = default;
             return false;
         }
 
     }
 
-    public async Task<TValue?> TryGetValueAsync<TValue>(string key, CancellationToken cancellation = default(CancellationToken))
+    public async Task<TValue?> TryGetValueAsync<TValue>(string key, CancellationToken cancellation = default)
     {
         CheckIfInitialized();
 
@@ -325,7 +325,7 @@ public abstract class BaseDistributeCache<T> : ICache
         }
         catch (Exception)
         {
-            return default(TValue);
+            return default;
         }
     }
 

--- a/src/Arc4u.Standard.Caching/ICache.cs
+++ b/src/Arc4u.Standard.Caching/ICache.cs
@@ -27,7 +27,7 @@ public interface ICache : IDisposable
     /// <param name="value">The object to save.</param>
     /// <returns>Return an <see cref="object"/> defining a version for the data added in the cache.</returns>
     /// <exception cref="DataCacheException">Thrown when the cache encounters a problem.</exception>
-    Task PutAsync<T>(string key, T value, CancellationToken cancellation = default(CancellationToken));
+    Task PutAsync<T>(string key, T value, CancellationToken cancellation = default);
 
     /// <summary>
     /// Add or set a value in the cache.
@@ -49,7 +49,7 @@ public interface ICache : IDisposable
     /// <param name="isSlided">A <see cref="bool"/> value indicating if the timeout period is reset again. If true, the data availability will be prolounge each time the data is accessed.</param>
     /// <returns>Return an <see cref="object"/> defining a version for the data added in the cache.</returns>
     /// <exception cref="DataCacheException">Thrown when the cache encounters a problem.</exception>
-    Task PutAsync<T>(string key, TimeSpan timeout, T value, bool isSlided = false, CancellationToken cancellation = default(CancellationToken));
+    Task PutAsync<T>(string key, TimeSpan timeout, T value, bool isSlided = false, CancellationToken cancellation = default);
 
     /// <summary>
     /// retrieve an <see cref="object"/> from the cache and cast it to the type of <see cref="TValue"/>.
@@ -69,7 +69,7 @@ public interface ICache : IDisposable
     /// <returns>An object typed to <see cref="TValue"/>, or the default value defined for the type <see cref="TValue"/> if no value exist for the specified key.</returns>
     /// <exception cref="DataCacheException">Thrown when the cache encounters a problem.</exception>
     /// <exception cref="InvalidCastException">Thrown when the <see cref="object"/> cannot be casted to the type <see cref="TValue"/> or when a cache has a problem.</exception>
-    Task<TValue?> GetAsync<TValue>(string key, CancellationToken cancellation = default(CancellationToken));
+    Task<TValue?> GetAsync<TValue>(string key, CancellationToken cancellation = default);
 
     /// <summary>
     /// Get a value from the cache, if a value exist for the specified key. Does not thrown an exception, if the cast to <see cref="TValue"/> is not possible.
@@ -86,7 +86,7 @@ public interface ICache : IDisposable
     /// <typeparam name="TValue">The type expected from the cache.</typeparam>
     /// <param name="key">The key used to identify the <see cref="object"/> in the cache.</param>
     /// <returns>An object typed to <see cref="TValue"/>. The default value defined for the type <see cref="TValue"/> if no value exist for the specified key or if the cast is not possible.</returns>
-    Task<TValue?> TryGetValueAsync<TValue>(string key, CancellationToken cancellation = default(CancellationToken));
+    Task<TValue?> TryGetValueAsync<TValue>(string key, CancellationToken cancellation = default);
 
     /// <summary>
     /// Rempve the data from the cache for the specified key.
@@ -100,5 +100,5 @@ public interface ICache : IDisposable
     /// </summary>
     /// <param name="key">The key used to identify the <see cref="object"/> in the cache.</param>
     /// <returns>True if the data was removed.</returns>
-    Task<bool> RemoveAsync(string key, CancellationToken cancellation = default(CancellationToken));
+    Task<bool> RemoveAsync(string key, CancellationToken cancellation = default);
 }

--- a/src/Arc4u.Standard.Configuration.Store/ISectionStoreExtensions.cs
+++ b/src/Arc4u.Standard.Configuration.Store/ISectionStoreExtensions.cs
@@ -24,7 +24,7 @@ public static class ISectionStoreExtensions
         var sectionEntity = await sectionStore.GetAsync(key, cancellationToken).ConfigureAwait(false);
         if (sectionEntity is null)
         {
-            return (false, default(TValue));
+            return (false, default);
         }
 
         return (true, sectionEntity.GetValue<TValue>());

--- a/src/Arc4u.Standard.Data/Data/EntitySet.cs
+++ b/src/Arc4u.Standard.Data/Data/EntitySet.cs
@@ -357,10 +357,10 @@ public sealed class EntitySet<TEntity>
 
     /// <summary>Determines whether an entity is in the <see cref="EntitySet&lt;TEntity&gt;"/>.</summary>
     /// <returns>true if entity is found in the <see cref="EntitySet&lt;TEntity&gt;"/>; otherwise, false.</returns>
-    /// <param name="entity">The object to locate in the <see cref="EntitySet&lt;TEntity&gt;"/>. The value can be null for reference types.</param>
-    public bool Contains(TEntity? entity)
+    /// <param name="item">The object to locate in the <see cref="EntitySet&lt;TEntity&gt;"/>. The value can be null for reference types.</param>
+    public bool Contains(TEntity? item)
     {
-        if (entity == null)
+        if (item == null)
         {
             for (var j = 0; j < _size; j++)
             {
@@ -378,7 +378,7 @@ public sealed class EntitySet<TEntity>
         var comparer = EqualityComparer<TEntity>.Default;
         for (var i = 0; i < size; i++)
         {
-            if (comparer.Equals(items[i], entity))
+            if (comparer.Equals(items[i], item))
             {
                 return true;
             }

--- a/src/Arc4u.Standard.Data/Data/EntitySet.cs
+++ b/src/Arc4u.Standard.Data/Data/EntitySet.cs
@@ -247,18 +247,18 @@ public sealed class EntitySet<TEntity>
     #endregion
 
     /// <summary>Adds an object to the end of the <see cref="EntitySet&lt;TEntity&gt;"/>.</summary>
-    /// <param name="entity">The object to be added to the end of the <see cref="EntitySet&lt;TEntity&gt;"/>. The value can be null for reference types.</param>
+    /// <param name="item">The object to be added to the end of the <see cref="EntitySet&lt;TEntity&gt;"/>. The value can be null for reference types.</param>
     /// <remarks>
     /// <para>This implementation raises the <see cref="CollectionChanged"/> event.</para>
     /// </remarks>
-    public void Add(TEntity entity)
+    public void Add(TEntity item)
     {
         CheckReentrancy();
         var index = _size;
-        AddItem(entity);
+        AddItem(item);
         OnPropertyChanged(nameof(Count));
         OnPropertyChanged(ItemPropertyName);
-        OnCollectionChanged(NotifyCollectionChangedAction.Add, entity, index);
+        OnCollectionChanged(NotifyCollectionChangedAction.Add, item, index);
     }
 
     /// <summary>Adds an object to the end of the <see cref="EntitySet&lt;TEntity&gt;"/>.</summary>
@@ -358,7 +358,7 @@ public sealed class EntitySet<TEntity>
     /// <summary>Determines whether an entity is in the <see cref="EntitySet&lt;TEntity&gt;"/>.</summary>
     /// <returns>true if entity is found in the <see cref="EntitySet&lt;TEntity&gt;"/>; otherwise, false.</returns>
     /// <param name="entity">The object to locate in the <see cref="EntitySet&lt;TEntity&gt;"/>. The value can be null for reference types.</param>
-    public bool Contains(TEntity entity)
+    public bool Contains(TEntity? entity)
     {
         if (entity == null)
         {
@@ -373,7 +373,7 @@ public sealed class EntitySet<TEntity>
         }
 
         var items = _items;
-        var size = _size; ;
+        var size = _size;
 
         var comparer = EqualityComparer<TEntity>.Default;
         for (var i = 0; i < size; i++)
@@ -485,7 +485,7 @@ public sealed class EntitySet<TEntity>
         }
 #endif
         var items = _items;
-        var size = _size; ;
+        var size = _size;
 
         for (var i = 0; i < size; i++)
         {

--- a/src/Arc4u.Standard.Dependency.ComponentModel/Arc4u.Standard.Dependency.ComponentModel.csproj
+++ b/src/Arc4u.Standard.Dependency.ComponentModel/Arc4u.Standard.Dependency.ComponentModel.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
     <PackageId>Arc4u.Standard.Dependency.ComponentModel</PackageId>
+    <NoWarn>$(NoWarn);IDE0130</NoWarn>
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />

--- a/src/Arc4u.Standard.Dependency.ComponentModel/ComponentModelContainer2.cs
+++ b/src/Arc4u.Standard.Dependency.ComponentModel/ComponentModelContainer2.cs
@@ -10,11 +10,11 @@ namespace Arc4u.Dependency.ComponentModel;
 
 public class ComponentModelContainer : IContainer
 {
-    public object Instance => _serviceProvider ?? throw new NullReferenceException("DI container is null.");
+    public object Instance => _serviceProvider ?? throw new InvalidOperationException("DI container is null.");
 
     public bool CanCreateScope => true;
 
-    public IServiceProvider ServiceProvider => _serviceProvider ?? throw new NullReferenceException("DI container is null.");
+    public IServiceProvider ServiceProvider => _serviceProvider ?? throw new InvalidOperationException("DI container is null.");
 
     readonly IServiceCollection? _collection;
     private readonly IServiceScope? _serviceScope;
@@ -43,7 +43,6 @@ public class ComponentModelContainer : IContainer
     /// <summary>
     /// Used when a specific call to create a scope instance is performed.
     /// </summary>
-    /// <param name="provider"></param>
     /// <param name="serviceScope"></param>
     protected ComponentModelContainer([DisallowNull] IServiceScope serviceScope)
     {

--- a/src/Arc4u.Standard.Diagnostics.Serilog/Formatter/SimpleTextFormatter.cs
+++ b/src/Arc4u.Standard.Diagnostics.Serilog/Formatter/SimpleTextFormatter.cs
@@ -87,8 +87,8 @@ internal static class DumpException
         var i = 0;
         foreach (var message in messages)
         {
-            sb.Append("".PadLeft(i++ * 4));
-            sb.Append("|---".PadLeft(i > 0 ? 4 : 0));
+            sb.Append("".PadLeft(i * 4));
+            sb.Append("|---".PadLeft(i++ > 0 ? 4 : 0));
             sb.AppendLine(message);
         }
 

--- a/src/Arc4u.Standard.Diagnostics.Serilog/Formatter/SimpleTextFormatter.cs
+++ b/src/Arc4u.Standard.Diagnostics.Serilog/Formatter/SimpleTextFormatter.cs
@@ -37,7 +37,7 @@ public class SimpleTextFormatter : ITextFormatter
     {
         try
         {
-            var (Category, Application, Identity, ClassType, MethodName, ActivityId, ProcessId, ThreadId, Stacktrace, Properties) = Helper.ExtractEventInfo(logEvent);
+            var (Category, _, Identity, ClassType, MethodName, ActivityId, ProcessId, ThreadId, Stacktrace, Properties) = Helper.ExtractEventInfo(logEvent);
 
             using var properties = new StringWriter();
             using var messageText = new StringWriter();

--- a/src/Arc4u.Standard.Diagnostics.Serilog/Formatter/SimpleTextFormatter.cs
+++ b/src/Arc4u.Standard.Diagnostics.Serilog/Formatter/SimpleTextFormatter.cs
@@ -69,9 +69,9 @@ public class SimpleTextFormatter : ITextFormatter
                 output.WriteLine(Stacktrace);
             }
         }
-        catch (Exception)
-        {
-        }
+        // We don't want to throw an exception and log this on the system who is assigned to log an information.
+        catch (Exception) { }
+
     }
 }
 

--- a/src/Arc4u.Standard.OAuth2.AspNetCore.Authentication/Extensions/AuthenticationExtensions.cs
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore.Authentication/Extensions/AuthenticationExtensions.cs
@@ -176,7 +176,7 @@ public static partial class AuthenticationExtensions
             throw new ConfigurationException($"No section exists with name {authenticationSectionName} in the configuration providers for OpenId Connect authentication.");
         }
 
-        var settings = section.Get<OidcAuthenticationSectionOptions>() ?? throw new NullReferenceException($"No section exists with name {authenticationSectionName} in the configuration providers for OpenId Connect authentication.");
+        var settings = section.Get<OidcAuthenticationSectionOptions>() ?? throw new InvalidOperationException($"No section exists with name {authenticationSectionName} in the configuration providers for OpenId Connect authentication.");
 
         string? configErrors = null;
         if (settings.DefaultAuthority is null)
@@ -259,10 +259,6 @@ public static partial class AuthenticationExtensions
         var cert = certificateLoader.FindCertificate(configuration, settings.CertificateSectionPath) ?? throw new MissingFieldException($"No certificate was found based on the configuration section: {settings.CertificateSectionPath}.");
 
         var ticketStoreAction = CacheTicketStoreExtension.PrepareAction(configuration, settings.AuthenticationCacheTicketStorePath);
-        if (null == ticketStoreAction)
-        {
-            throw new MissingFieldException("A TicketStore is mandatory to store the authentication ticket.");
-        }
 
         Type? cookiesConfigureOptionsType;
         if (string.IsNullOrWhiteSpace(settings.CookiesConfigureOptionsType))
@@ -388,8 +384,8 @@ public static partial class AuthenticationExtensions
         ArgumentNullException.ThrowIfNull(configuration);
         ArgumentNullException.ThrowIfNull(authenticationSectionName);
 
-        var section = configuration.GetSection(authenticationSectionName) ?? throw new NullReferenceException($"No section exists with name {authenticationSectionName} in the configuration providers for OAuth2 Connect authentication.");
-        var settings = section.Get<JwtAuthenticationSectionOptions>() ?? throw new NullReferenceException($"No section exists with name {authenticationSectionName} in the configuration providers for OAuth2 Connect authentication.");
+        var section = configuration.GetSection(authenticationSectionName) ?? throw new InvalidOperationException($"No section exists with name {authenticationSectionName} in the configuration providers for OAuth2 Connect authentication.");
+        var settings = section.Get<JwtAuthenticationSectionOptions>() ?? throw new InvalidOperationException($"No section exists with name {authenticationSectionName} in the configuration providers for OAuth2 Connect authentication.");
 
         if (settings.DefaultAuthority is null)
         {

--- a/src/Arc4u.Standard.OAuth2.AspNetCore.Authentication/TicketStore/CacheTicketStoreExtension.cs
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore.Authentication/TicketStore/CacheTicketStoreExtension.cs
@@ -43,13 +43,7 @@ public static class CacheTicketStoreExtension
 
         if (section.Exists())
         {
-            var option = configuration.GetSection(sectionName).Get<CacheTicketStoreOptions>();
-
-            if (option is null)
-            {
-                throw new InvalidOperationException($"Section nameof(option) cannot be deserialize to CacheTicketStoreOptions");
-            }
-
+            var option = configuration.GetSection(sectionName).Get<CacheTicketStoreOptions>() ?? throw new InvalidOperationException($"Section nameof(option) cannot be deserialize to CacheTicketStoreOptions");
             void options(CacheTicketStoreOptions o)
             {
                 o.CacheName = option.CacheName;

--- a/src/Arc4u.Standard.OAuth2.AspNetCore.Authentication/TicketStore/CacheTicketStoreExtension.cs
+++ b/src/Arc4u.Standard.OAuth2.AspNetCore.Authentication/TicketStore/CacheTicketStoreExtension.cs
@@ -47,7 +47,7 @@ public static class CacheTicketStoreExtension
 
             if (option is null)
             {
-                throw new NullReferenceException(nameof(option));
+                throw new InvalidOperationException($"Section nameof(option) cannot be deserialize to CacheTicketStoreOptions");
             }
 
             void options(CacheTicketStoreOptions o)

--- a/src/Arc4u.Standard.OAuth2/Arc4u.Standard.OAuth2.csproj
+++ b/src/Arc4u.Standard.OAuth2/Arc4u.Standard.OAuth2.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
     <PackageId>Arc4u.Standard.OAuth2</PackageId>
+    <NoWarn>$(NoWarn);IDE0130</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.1.2" />

--- a/src/Arc4u.Standard.OAuth2/Token/ApplicationCache.cs
+++ b/src/Arc4u.Standard.OAuth2/Token/ApplicationCache.cs
@@ -7,57 +7,47 @@ using Microsoft.Extensions.Options;
 
 namespace Arc4u.OAuth2.Token;
 
+/// <summary>
+/// Read the cache used to store the tokens! If nothing is identified, Default is used!
+/// </summary>
 [Export(typeof(ITokenCache)), Shared]
-public class ApplicationCache : ITokenCache
+public class ApplicationCache(ICacheHelper cacheHelper, ILogger logger, IOptions<TokenCacheOptions> options) : ITokenCache
 {
-    /// <summary>
-    /// Read the cache used to store the tokens! If nothing is identified, Default is used!
-    /// </summary>
-    public ApplicationCache(ICacheContext cacheContext, ICacheHelper cacheHelper, ILogger logger, IOptions<TokenCacheOptions> options)
-    {
-        _logger = logger;
-        _cacheContext = cacheContext;
-        _cache = cacheHelper.GetCache();
-        _tokenCacheOptions = options.Value;
-    }
-
-    private readonly ICache _cache;
-    private readonly ICacheContext _cacheContext;
-    private readonly ILogger _logger;
-    private readonly TokenCacheOptions _tokenCacheOptions;
+    private readonly ICache _cache = cacheHelper.GetCache();
+    private readonly TokenCacheOptions _tokenCacheOptions = options.Value;
 
     /// <summary>
     /// Remove at the same time the token and the extra claims added to the cache via a call to an implementation of the IClaimsFiller...
     /// </summary>
-    /// <param name="id"></param>
-    public void DeleteItem(string id)
+    /// <param name="key"></param>
+    public void DeleteItem(string key)
     {
-        _logger.Technical().From<ApplicationCache>().System($"Deleting information from the token cache for the id: {id}.").Log();
-        _cache.Remove(ApplicationCache.GetKey(id));
-        _logger.Technical().From<ApplicationCache>().System($"Deleted information from the token cache for the id: {id}.").Log();
+        logger.Technical().From<ApplicationCache>().System($"Deleting information from the token cache for the id: {key}.").Log();
+        _cache.Remove(ApplicationCache.GetKey(key));
+        logger.Technical().From<ApplicationCache>().System($"Deleted information from the token cache for the id: {key}.").Log();
     }
 
     public void Put<T>(string key, T data)
     {
         if (null == data)
         {
-            _logger.Technical().From<ApplicationCache>().System("A null token data information was provided to the cache. We skip this data from the cache.");
+            logger.Technical().From<ApplicationCache>().System("A null token data information was provided to the cache. We skip this data from the cache.");
             return;
         }
 
-        _logger.Technical().From<ApplicationCache>().System($"Adding token data information to the cache: {key}.").Log();
+        logger.Technical().From<ApplicationCache>().System($"Adding token data information to the cache: {key}.").Log();
         _cache.Put(ApplicationCache.GetKey(key), _tokenCacheOptions.MaxTime, data);
-        _logger.Technical().From<ApplicationCache>().System($"Added token data information to the cache: {key}.").Log();
+        logger.Technical().From<ApplicationCache>().System($"Added token data information to the cache: {key}.").Log();
     }
 
-    public T? Get<T>(string id)
+    public T? Get<T>(string key)
     {
-        _logger.Technical().From<ApplicationCache>().System($"Retrieve token information for user: {id}.").Log();
-        var data = _cache.Get<T>(ApplicationCache.GetKey(id));
+        logger.Technical().From<ApplicationCache>().System($"Retrieve token information for user: {key}.").Log();
+        var data = _cache.Get<T>(ApplicationCache.GetKey(key));
 
         if (null == data)
         {
-            _logger.Technical().From<ApplicationCache>().System($"The data in cache is null for user: {id}.").Log();
+            logger.Technical().From<ApplicationCache>().System($"The data in cache is null for user: {key}.").Log();
         }
 
         return data;
@@ -65,7 +55,7 @@ public class ApplicationCache : ITokenCache
 
     public IEnumerable<byte[]> GetAll()
     {
-        _logger.Technical().From<ApplicationCache>().Warning("Geting all data from the token cache is not implemented.").Log();
+        logger.Technical().From<ApplicationCache>().Warning("Geting all data from the token cache is not implemented.").Log();
 
         return [];
     }

--- a/src/Arc4u.Standard.Threading/Arc4u.Standard.Threading.csproj
+++ b/src/Arc4u.Standard.Threading/Arc4u.Standard.Threading.csproj
@@ -3,5 +3,6 @@
     <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
     <PackageId>Arc4u.Standard.Threading</PackageId>
     <Description>Core threading Framework used to build application.</Description>
+    <NoWarn>$(NoWarn);IDE0130</NoWarn>
   </PropertyGroup>
 </Project>

--- a/src/Arc4u.Standard.Threading/Scope!2.cs
+++ b/src/Arc4u.Standard.Threading/Scope!2.cs
@@ -15,7 +15,7 @@ public class Scope<TScope, TInstance> : IDisposable
     private bool ToDispose { get; set; }
     private Scope<TScope, TInstance>? Parent { get; set; }
 
-    private TInstance Value;
+    private TInstance? Value;
 
     /// <summary>
     /// Prevents a default instance of the <see cref="Scope&lt;T&gt;"/> class from being created.

--- a/src/Arc4u.Standard.Threading/Scope.cs
+++ b/src/Arc4u.Standard.Threading/Scope.cs
@@ -8,13 +8,13 @@ namespace Arc4u.Threading;
 /// <typeparam name="T">Any type.</typeparam>
 public class Scope<T> : IDisposable
 {
-    private static readonly AsyncLocal<Scope<T>?> _instance = new AsyncLocal<Scope<T>?>();
+    private static readonly AsyncLocal<Scope<T>?> _instance = new();
 
     private bool Disposed { get; set; }
     private bool ToDispose { get; set; }
     private Scope<T>? Parent { get; set; }
 
-    private T Value;
+    private T? Value;
 
     /// <summary>
     /// Prevents a default instance of the <see cref="Scope&lt;T&gt;"/> class from being created.
@@ -28,8 +28,7 @@ public class Scope<T> : IDisposable
     /// Initializes a new instance of the <see cref="Scope&lt;T&gt;"/> class.
     /// </summary>
     /// <param name="instance">The instance.</param>
-    public Scope(T instance)
-        : this(instance, true)
+    public Scope(T instance) : this(instance, true)
     {
     }
 
@@ -70,7 +69,7 @@ public class Scope<T> : IDisposable
 
     protected T? ParentValue
     {
-        get { return null == Parent ? default(T) : Parent.Value; }
+        get { return null == Parent ? default : Parent.Value; }
     }
 
     /// <summary>

--- a/src/Arc4u.Standard.UnitTest/Database/MongoDBTests.cs
+++ b/src/Arc4u.Standard.UnitTest/Database/MongoDBTests.cs
@@ -21,7 +21,7 @@ public class MongoDBTests
 
     private readonly Fixture _fixture;
 
-    private class Contract
+    private sealed class Contract
     {
         public Guid Id { get; set; }
         public string Name { get; set; } = default!;

--- a/src/Arc4u.Standard/FlagsEnum.cs
+++ b/src/Arc4u.Standard/FlagsEnum.cs
@@ -18,13 +18,12 @@ public static class FlagsEnum
     /// <typeparamref name="TEnum"/> is not an enumeration type -or-
     /// no match found in the defined values of <typeparamref name="TEnum"/>.
     /// </exception>
-    public static TEnum PowerOfTwo<TEnum>(object power)
-        where TEnum : struct
+    public static TEnum PowerOfTwo<TEnum>(object power) where TEnum : struct
     {
         var type = typeof(TEnum);
         if (!type.GetTypeInfo().IsEnum)
         {
-            throw new ArgumentException("Type provided must be an enumeration.", "TEnum");
+            throw new InvalidOperationException($"Type {nameof(TEnum)} provided must be an enumeration.");
         }
 
         if (TryPowerOfTwo(power, out TEnum result))
@@ -43,7 +42,7 @@ public static class FlagsEnum
     /// <param name="result">When this methods returns, contains the matching value of <typeparamref name="TEnum"/>. This parameter is passed uninitialized.</param>        
     /// <returns><b>true</b> if a matching value of <typeparamref name="TEnum"/> is found; otherwise, <b>false</b>.</returns>
     public static bool TryPowerOfTwo<TEnum>(object power, out TEnum result)
-        where TEnum : struct
+                                            where TEnum : struct
     {
         result = default;
         var type = typeof(TEnum);

--- a/src/Arc4u.Standard/FlagsEnum.cs
+++ b/src/Arc4u.Standard/FlagsEnum.cs
@@ -41,7 +41,7 @@ public static class FlagsEnum
     /// <param name="power">The raising power of two.</param>
     /// <param name="result">When this methods returns, contains the matching value of <typeparamref name="TEnum"/>. This parameter is passed uninitialized.</param>        
     /// <returns><b>true</b> if a matching value of <typeparamref name="TEnum"/> is found; otherwise, <b>false</b>.</returns>
-    public static bool TryPowerOfTwo<TEnum>(object power, out TEnum result)
+    public static bool TryPowerOfTwo<TEnum>(object power, out TEnum result, float epsilon = 0.0000001f)
                                             where TEnum : struct
     {
         result = default;
@@ -57,7 +57,7 @@ public static class FlagsEnum
         }
 
         var v = Math.Pow(2, Convert.ToDouble(power, CultureInfo.InvariantCulture));
-        if (Math.Floor(v) != v)
+        if (Math.Floor(v) - v > epsilon)
         {
             return false;
         }
@@ -140,7 +140,7 @@ public static class FlagsEnum
     /// <param name="value">A value.</param>
     /// <param name="result">When this methods returns, contains the power of two exponent from the specified <paramref name="value"/>. This parameter is passed uninitialized.</param>
     /// <returns><b>true</b> if the <paramref name="value"/> parameter is a power of two exponent; otherwise, <b>false</b>.</returns>
-    public static bool TryPowerOfTwoExponent(object? value, out int result)
+    public static bool TryPowerOfTwoExponent(object? value, out int result, float epsilon = 0.0000001f)
     {
         result = 0;
         if (value == null || !typeof(IConvertible).GetTypeInfo().IsAssignableFrom(value.GetType().GetTypeInfo()))
@@ -149,7 +149,7 @@ public static class FlagsEnum
         }
 
         var v = Math.Log(Convert.ToDouble(value, CultureInfo.InvariantCulture), 2);
-        if (Math.Floor(v) != v)
+        if (Math.Floor(v) - v > epsilon)
         {
             return false;
         }
@@ -170,7 +170,7 @@ public static class FlagsEnum
         var type = typeof(TEnum);
         if (!type.GetTypeInfo().IsEnum)
         {
-            throw new ArgumentException("Type provided must be an enumeration.", "TEnum");
+            throw new InvalidOperationException($"Type {nameof(TEnum)} provided must be an enumeration.");
         }
 
         // call an inner method to avoid deferred argument check
@@ -190,37 +190,6 @@ public static class FlagsEnum
     }
 
     /// <summary>
-    /// Gets the flagged values defined in <typeparamref name="TEnum"/>.
-    /// </summary>
-    /// <typeparam name="TEnum">An enumeration type.</typeparam>
-    /// <returns>The defined flagged values.</returns>
-    /// <exception cref="ArgumentException"><typeparamref name="TEnum"/> is not an enumeration type.</exception>
-    public static IEnumerable<TEnum> FlaggedValues<TEnum>()
-        where TEnum : struct
-    {
-        var type = typeof(TEnum);
-        if (!type.GetTypeInfo().IsEnum)
-        {
-            throw new ArgumentException("Type provided must be an enumeration.", "TEnum");
-        }
-
-        // call an inner method to avoid deferred argument check
-        return FlaggedValues<TEnum>(type);
-    }
-
-    static IEnumerable<TEnum> FlaggedValues<TEnum>(Type type)
-        where TEnum : struct
-    {
-        foreach (TEnum value in Enum.GetValues(type))
-        {
-            if (!TryPowerOfTwoExponent(value, out _))
-            {
-                yield return value;
-            }
-        }
-    }
-
-    /// <summary>
     /// Gets the flag values of the specified <paramref name="value"/>.
     /// </summary>
     /// <typeparam name="TEnum">An enumeration type.</typeparam>
@@ -233,7 +202,7 @@ public static class FlagsEnum
         var type = typeof(TEnum);
         if (!type.GetTypeInfo().IsEnum)
         {
-            throw new ArgumentException("Type provided must be an enumeration.", "TEnum");
+            throw new InvalidOperationException($"Type {nameof(TEnum)} provided must be an enumeration.");
         }
 
         // call an inner method to avoid deferred argument check
@@ -253,6 +222,37 @@ public static class FlagsEnum
     }
 
     /// <summary>
+    /// Gets the flagged values defined in <typeparamref name="TEnum"/>.
+    /// </summary>
+    /// <typeparam name="TEnum">An enumeration type.</typeparam>
+    /// <returns>The defined flagged values.</returns>
+    /// <exception cref="ArgumentException"><typeparamref name="TEnum"/> is not an enumeration type.</exception>
+    public static IEnumerable<TEnum> FlaggedValues<TEnum>()
+        where TEnum : struct
+    {
+        var type = typeof(TEnum);
+        if (!type.GetTypeInfo().IsEnum)
+        {
+            throw new InvalidOperationException($"Type {nameof(TEnum)} provided must be an enumeration.");
+        }
+
+        // call an inner method to avoid deferred argument check
+        return FlaggedValues<TEnum>(type);
+    }
+
+    static IEnumerable<TEnum> FlaggedValues<TEnum>(Type type)
+        where TEnum : struct
+    {
+        foreach (TEnum value in Enum.GetValues(type))
+        {
+            if (!TryPowerOfTwoExponent(value, out _))
+            {
+                yield return value;
+            }
+        }
+    }
+
+    /// <summary>
     /// Indicates if the flag values of the specified <paramref name="value"/> are continuous or not.
     /// </summary>
     /// <typeparam name="TEnum">An enumeration type.</typeparam>
@@ -265,7 +265,7 @@ public static class FlagsEnum
         var type = typeof(TEnum);
         if (!type.GetTypeInfo().IsEnum)
         {
-            throw new ArgumentException("Type provided must be an enumeration.", "TEnum");
+            throw new InvalidOperationException($"Type {nameof(TEnum)} provided must be an enumeration.");
         }
 
         // call an inner method to avoid deferred argument check

--- a/src/Arc4u.Standard/Utils/Enum.cs
+++ b/src/Arc4u.Standard/Utils/Enum.cs
@@ -51,7 +51,7 @@ public readonly struct Enum<T>(T value) : IEnumerable<T>
 
     readonly IEnumerator<T> IEnumerable<T>.GetEnumerator()
     {
-        foreach (var value in EnumUtil.GetValues(typeof(T), true))
+        foreach (var item in EnumUtil.GetValues(typeof(T), true))
         {
             switch (Convert.GetTypeCode(_value))
             {
@@ -59,9 +59,9 @@ public readonly struct Enum<T>(T value) : IEnumerable<T>
                 case TypeCode.Int16:
                 case TypeCode.Int32:
                 case TypeCode.Int64:
-                    if ((Convert.ToInt64(_value, CultureInfo.InvariantCulture) & Convert.ToInt64(value, CultureInfo.InvariantCulture)) == Convert.ToInt64(value, CultureInfo.InvariantCulture))
+                    if ((Convert.ToInt64(_value, CultureInfo.InvariantCulture) & Convert.ToInt64(item, CultureInfo.InvariantCulture)) == Convert.ToInt64(item, CultureInfo.InvariantCulture))
                     {
-                        yield return (T)Enum.ToObject(typeof(T), value);
+                        yield return (T)Enum.ToObject(typeof(T), item);
                     }
 
                     break;
@@ -69,9 +69,9 @@ public readonly struct Enum<T>(T value) : IEnumerable<T>
                 case TypeCode.UInt16:
                 case TypeCode.UInt32:
                 case TypeCode.UInt64:
-                    if ((Convert.ToUInt64(_value, CultureInfo.InvariantCulture) & Convert.ToUInt64(value, CultureInfo.InvariantCulture)) != Convert.ToUInt64(value, CultureInfo.InvariantCulture))
+                    if ((Convert.ToUInt64(_value, CultureInfo.InvariantCulture) & Convert.ToUInt64(item, CultureInfo.InvariantCulture)) != Convert.ToUInt64(item, CultureInfo.InvariantCulture))
                     {
-                        yield return (T)Enum.ToObject(typeof(T), value);
+                        yield return (T)Enum.ToObject(typeof(T), item);
                     }
 
                     break;
@@ -361,7 +361,7 @@ public struct EnumUtil
         }
 
         var type = value.GetType();
-        if (!(type == typeof(string)) && !type.GetTypeInfo().IsSubclassOf(typeof(ValueType)))
+        if ((type != typeof(string)) && !type.GetTypeInfo().IsSubclassOf(typeof(ValueType)))
         {
             return new ArgumentException(Arg_MustBeValueTypeOrstring, nameof(value));
         }
@@ -371,13 +371,13 @@ public struct EnumUtil
         {
             if (type != typeof(T))
             {
-                return new ArgumentException(string.Format(CultureInfo.CurrentCulture, Arg_EnumAndObjectMustBeSameType, [type.ToString(), typeof(T).ToString()]));
+                return new ArgumentException(string.Format(CultureInfo.InvariantCulture, Arg_EnumAndObjectMustBeSameType, type.ToString(), typeof(T).ToString()));
             }
             type = Enum.GetUnderlyingType(type);
         }
         else if (type != underlyingType && !(type == typeof(string)))
         {
-            return new ArgumentException(string.Format(CultureInfo.CurrentCulture, Arg_EnumUnderlyingTypeAndObjectMustBeSameType, [type.ToString(), underlyingType.ToString()]));
+            return new ArgumentException(string.Format(CultureInfo.InvariantCulture, Arg_EnumUnderlyingTypeAndObjectMustBeSameType, type.ToString(), underlyingType.ToString()));
         }
 
         if (type == typeof(string))


### PR DESCRIPTION
Add new behavior in [`MemoryCache`](https://github.com/GFlisch/Arc4u/blob/master/src/Arc4u.Standard.Caching.Memory/MemoryCache.cs).
If the `SizeLimitInMB` is not greater than 0, a warning is issued since the interpretation of that value is implementation dependent. It was reported that a zero value would disable the cache altogether, which let to some confusion about the cause.